### PR TITLE
Add httpx dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 sqlmodel
 pydantic
+httpx


### PR DESCRIPTION
## Summary
- add `httpx` to backend requirements

## Testing
- `PYTHONPATH=backend pytest -q tests/test_main.py`

------
https://chatgpt.com/codex/tasks/task_b_6840ac70bda883269625f81977ad823a