### PR TITLE
Add Docker build and run instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Build frontend
+FROM node:18 AS frontend
+WORKDIR /app/frontend
+COPY frontend/package*.json ./
+RUN npm install
+COPY frontend .
+RUN npm run build
+
+# Final image
+FROM python:3.11-slim
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY backend/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend ./backend
+COPY --from=frontend /app/frontend/dist ./frontend/dist
+EXPOSE 8080
+WORKDIR /app/backend
+CMD ["uvicorn", "resistor.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,24 @@ docker run -d \
   -e TZ=America/Chicago \
   -e RESISTOR_DATA=/data \
   -v /path/on/host:/data \
-  ghcr.io/yourname/resistor:latest
+ghcr.io/yourname/resistor:latest
+```
+
+## Building the container
+
+To build the image yourself, run from the repository root:
+
+```sh
+docker build -t resistor .
+```
+
+Then start the container:
+
+```sh
+docker run -d \
+  --name resistor \
+  -p 8080:8080 \
+  resistor
 ```
 
 The container detects architecture and selects the correct image variant.


### PR DESCRIPTION
## Summary
- create a Dockerfile to build the frontend and run FastAPI
- document how to build and run the Docker image

## Testing
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6840ac8cd4508326abd1cca470dec5f5