### PR TITLE
Add Dockerfile and container usage docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20 AS frontend-build
+WORKDIR /app/frontend
+COPY frontend/package.json .
+COPY frontend/package-lock.json* ./
+RUN npm install
+COPY frontend .
+RUN npm run build
+
+FROM python:3.11-slim
+WORKDIR /app
+COPY backend/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend ./
+COPY --from=frontend-build /app/frontend/dist ./frontend/dist
+EXPOSE 8080
+CMD ["uvicorn", "resistor.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ The React app currently renders only a heading that says "Resistor". It is inclu
 
 This script starts both the FastAPI server on port 8080 and the Vite dev server for the React app.
 
+## Docker
+
+To build and run the production container:
+
+```sh
+docker build -t resistor .
+docker run -p 8080:8080 resistor
+```
+
+The image installs the Python requirements, installs the Node packages to build
+the frontend and finally launches the API with `uvicorn`.
+
 # Roadmap
 
 The following planned features are not yet implemented:


### PR DESCRIPTION
## Summary
- add a Dockerfile to build the React frontend and run the FastAPI backend
- document how to build and run the container

## Testing
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6840ae6936c4832681781d33f167b6a3