### PR TITLE
Pin httpx version for backend tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,3 +6,5 @@ This directory contains the FastAPI application. Install requirements and run th
 pip install -r requirements.txt
 uvicorn resistor.main:app --reload --port 8080
 ```
+
+The requirements file pins `httpx` below 0.27 to avoid compatibility issues.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,4 +2,4 @@ fastapi
 uvicorn
 sqlmodel
 pydantic
-httpx
+httpx==0.26.*


### PR DESCRIPTION
## Summary
- pin `httpx` dependency below v0.27
- add note in backend README about the pinned requirement

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install -r backend/requirements.txt`
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6840b2bdf6b883268d92678d412b5bf5