### PR TITLE
Add health check endpoint and Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY backend ./
 COPY --from=frontend-build /app/frontend/dist ./frontend/dist
 EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8080/healthz || exit 1
 CMD ["uvicorn", "resistor.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/resistor/main.py
+++ b/backend/resistor/main.py
@@ -8,6 +8,12 @@ from .schemas import HabitCreate, HabitRead, EventCreate, EventRead
 app = FastAPI(title="Resistor API")
 
 
+@app.get("/healthz")
+def healthz():
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
 @app.on_event("startup")
 def on_startup():
     init_db()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,12 @@ from resistor.database import init_db
 client = TestClient(app)
 
 
+def test_healthz():
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
 def test_create_and_list_habit():
     init_db()
     response = client.post("/habits", json={"name": "Test"})


### PR DESCRIPTION
## Summary
- expose `/healthz` endpoint from FastAPI app
- test the health endpoint
- add container healthcheck command to Dockerfile

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6841a526612c8326b334b7118d0ad33a