### PR TITLE
Add data export endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -8,3 +8,7 @@ uvicorn resistor.main:app --reload --port 8080
 ```
 
 The requirements file pins `httpx` below 0.27 to avoid compatibility issues.
+
+## Endpoints
+
+* `GET /export` – return all habits and events in a single JSON payload.

--- a/backend/resistor/main.py
+++ b/backend/resistor/main.py
@@ -50,3 +50,14 @@ def create_event(event: EventCreate, session=Depends(get_session)):
 def list_events(session=Depends(get_session)):
     events = session.exec(select(Event)).all()
     return events
+
+
+@app.get("/export")
+def export_data(session=Depends(get_session)):
+    """Export all habits and events as JSON."""
+    habits = session.exec(select(Habit)).all()
+    events = session.exec(select(Event)).all()
+    return {
+        "habits": [HabitRead.model_validate(h, from_attributes=True) for h in habits],
+        "events": [EventRead.model_validate(e, from_attributes=True) for e in events],
+    }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,3 +50,20 @@ def test_create_event_invalid_habit():
         "/events", json={"habit_id": 999999, "success": True}
     )
     assert response.status_code == 404
+
+
+def test_export_data():
+    init_db()
+    habit_resp = client.post("/habits", json={"name": "Export Habit"})
+    habit_id = habit_resp.json()["id"]
+    event_resp = client.post(
+        "/events",
+        json={"habit_id": habit_id, "success": False},
+    )
+    event_id = event_resp.json()["id"]
+
+    response = client.get("/export")
+    assert response.status_code == 200
+    data = response.json()
+    assert any(h["id"] == habit_id for h in data["habits"])
+    assert any(e["id"] == event_id for e in data["events"])


### PR DESCRIPTION
## Summary
- add `/export` route to return habits and events
- test exporting data after creating some habits and events
- document new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6841a63df26c8326ac0423e32001b805