### PR TITLE
Add delete event endpoint

### DIFF
--- a/backend/resistor/main.py
+++ b/backend/resistor/main.py
@@ -52,6 +52,17 @@ def list_events(session=Depends(get_session)):
     return events
 
 
+@app.delete("/events/{event_id}")
+def delete_event(event_id: int, session=Depends(get_session)):
+    """Delete a single event by id."""
+    event = session.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    session.delete(event)
+    session.commit()
+    return {"status": "deleted"}
+
+
 @app.get("/export")
 def export_data(session=Depends(get_session)):
     """Export all habits and events as JSON."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -67,3 +67,24 @@ def test_export_data():
     data = response.json()
     assert any(h["id"] == habit_id for h in data["habits"])
     assert any(e["id"] == event_id for e in data["events"])
+
+
+def test_delete_event():
+    init_db()
+    habit = client.post("/habits", json={"name": "Delete Habit"}).json()
+    event = client.post(
+        "/events",
+        json={"habit_id": habit["id"], "success": True},
+    ).json()
+
+    del_resp = client.delete(f"/events/{event['id']}")
+    assert del_resp.status_code == 200
+
+    events = client.get("/events").json()
+    assert all(e["id"] != event["id"] for e in events)
+
+
+def test_delete_event_not_found():
+    init_db()
+    response = client.delete("/events/9999")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- allow deleting an event with `DELETE /events/{event_id}`
- test deleting events

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6841a9fc6b588326b9215f6b16f832fc