### PR TITLE
Add import endpoint with round-trip tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -12,3 +12,4 @@ The requirements file pins `httpx` below 0.27 to avoid compatibility issues.
 ## Endpoints
 
 * `GET /export` – return all habits and events in a single JSON payload.
+* `POST /import` – restore habits and events from an exported JSON payload.

--- a/backend/resistor/schemas.py
+++ b/backend/resistor/schemas.py
@@ -21,3 +21,9 @@ class EventCreate(BaseModel):
 class EventRead(EventCreate):
     id: int
     timestamp: datetime
+
+
+class ExportBundle(BaseModel):
+    """Payload used for full data export/import."""
+    habits: list[HabitRead]
+    events: list[EventRead]


### PR DESCRIPTION
## Summary
- implement `/import` API to restore exported data
- add `ExportBundle` schema
- document `/import` endpoint
- test export->delete->import round-trip

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6841aaf65084832689b6c0c209f71b35