### PR TITLE
Add habit archival feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The backend uses SQLite through SQLModel and the frontend is bootstrapped with V
 # API Endpoints
 
 * `POST /habits` – create a habit with a name, optional description, colour and icon.
-* `GET /habits` – list all habits.
-* `PATCH /habits/{id}` – update a habit's details.
+* `GET /habits` – list all active habits. Pass `include_archived=true` to include archived ones.
+* `PATCH /habits/{id}` – update a habit's details (name, colour, etc.) or archive it.
 * `DELETE /habits/{id}` – remove a habit and its events.
 * `POST /events` – log a success or slip against a habit.
 * `GET /events` – list all logged events.

--- a/backend/resistor/main.py
+++ b/backend/resistor/main.py
@@ -36,8 +36,11 @@ def create_habit(habit: HabitCreate, session=Depends(get_session)):
 
 
 @app.get("/habits", response_model=list[HabitRead])
-def list_habits(session=Depends(get_session)):
-    habits = session.exec(select(Habit)).all()
+def list_habits(include_archived: bool = False, session=Depends(get_session)):
+    query = select(Habit)
+    if not include_archived:
+        query = query.where(Habit.archived == False)  # noqa: E712
+    habits = session.exec(query).all()
     return habits
 
 

--- a/backend/resistor/models.py
+++ b/backend/resistor/models.py
@@ -8,6 +8,7 @@ class Habit(SQLModel, table=True):
     description: str | None = None
     color: str | None = None
     icon: str | None = None
+    archived: bool = Field(default=False)
 
 
 class Event(SQLModel, table=True):

--- a/backend/resistor/schemas.py
+++ b/backend/resistor/schemas.py
@@ -7,6 +7,7 @@ class HabitCreate(BaseModel):
     description: str | None = None
     color: str | None = None
     icon: str | None = None
+    archived: bool = False
 
 
 class HabitRead(HabitCreate):
@@ -19,6 +20,7 @@ class HabitUpdate(BaseModel):
     description: str | None = None
     color: str | None = None
     icon: str | None = None
+    archived: bool | None = None
 
 
 class EventCreate(BaseModel):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -79,6 +79,21 @@ def test_update_habit():
     assert any(h["id"] == habit["id"] and h["name"] == "New" for h in listed)
 
 
+def test_archive_habit():
+    init_db()
+    habit = client.post("/habits", json={"name": "Archivable"}).json()
+
+    resp = client.patch(f"/habits/{habit['id']}", json={"archived": True})
+    assert resp.status_code == 200
+    assert resp.json()["archived"] is True
+
+    default_list = client.get("/habits").json()
+    assert all(h["id"] != habit["id"] for h in default_list)
+
+    archived_list = client.get("/habits", params={"include_archived": "true"}).json()
+    assert any(h["id"] == habit["id"] for h in archived_list)
+
+
 def test_delete_habit():
     init_db()
     habit = client.post("/habits", json={"name": "To Remove"}).json()


### PR DESCRIPTION
## Summary
- add `archived` field to `Habit` model and schemas
- add query parameter to list archived habits
- document archival support in README
- test archiving habits

## Testing
- `pip install -q -r backend/requirements.txt`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6841b26fb56c83269c5fd15ef8ce6bbc