### PR TITLE
Implement quick logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The backend uses SQLite through SQLModel and the frontend is bootstrapped with V
 
 # Frontend
 
-The React app currently renders only a heading that says "Resistor". It is included so the backend can serve a basic SPA bundle.
+The React app lets you manage habits and quickly log events. A dropdown at the top acts as a quick switcher for the active habit, and Resist/Slip buttons record successes or failures. After logging you are prompted for an optional note and see a brief alert as feedback.
 
 # Quick Start (Development)
 

--- a/backend/resistor/models.py
+++ b/backend/resistor/models.py
@@ -19,3 +19,4 @@ class Event(SQLModel, table=True):
     success: bool
     latitude: float | None = None
     longitude: float | None = None
+    note: str | None = None

--- a/backend/resistor/schemas.py
+++ b/backend/resistor/schemas.py
@@ -30,6 +30,7 @@ class EventCreate(BaseModel):
     success: bool
     latitude: float | None = None
     longitude: float | None = None
+    note: str | None = None
 
 
 class EventRead(EventCreate):

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 
 function App() {
   const [habits, setHabits] = useState([]);
+  const [activeHabit, setActiveHabit] = useState(null);
   const [form, setForm] = useState({
     name: '',
     description: '',
@@ -23,6 +24,12 @@ function App() {
       .then(setHabits)
       .catch(() => setHabits([]));
   }, []);
+
+  useEffect(() => {
+    if (habits.length > 0 && !activeHabit) {
+      setActiveHabit(habits[0].id);
+    }
+  }, [habits, activeHabit]);
 
   function createHabit(e) {
     e.preventDefault();
@@ -69,6 +76,7 @@ function App() {
   }
 
   function logEvent(habitId, success) {
+    const note = prompt('Add a note (optional)') || null;
     const send = (lat, lon) => {
       fetch('/events', {
         method: 'POST',
@@ -78,7 +86,12 @@ function App() {
           success,
           latitude: lat,
           longitude: lon,
+          note,
         }),
+      }).then(() => {
+        if (success) {
+          alert('Great job!');
+        }
       });
     };
 
@@ -95,6 +108,22 @@ function App() {
   return (
     <div>
       <h1>Resistor</h1>
+      {habits.length > 0 && (
+        <div style={{ marginBottom: '1em' }}>
+          <select
+            value={activeHabit || ''}
+            onChange={(e) => setActiveHabit(Number(e.target.value))}
+          >
+            {habits.map((h) => (
+              <option key={h.id} value={h.id}>
+                {h.name}
+              </option>
+            ))}
+          </select>{' '}
+          <button onClick={() => logEvent(activeHabit, true)}>Resist</button>{' '}
+          <button onClick={() => logEvent(activeHabit, false)}>Slip</button>
+        </div>
+      )}
       <form onSubmit={createHabit} style={{ marginBottom: '1em' }}>
         <input
           placeholder="Name"
@@ -157,7 +186,7 @@ function App() {
             {habit.icon && <span>{habit.icon} </span>}
             <span style={{ color: habit.color || 'inherit' }}>{habit.name}</span>
             {habit.description ? ` - ${habit.description}` : ''}{' '}
-            <button onClick={() => logEvent(habit.id, true)}>Success</button>{' '}
+            <button onClick={() => logEvent(habit.id, true)}>Resist</button>{' '}
             <button onClick={() => logEvent(habit.id, false)}>Slip</button>{' '}
             <button onClick={() => startEdit(habit)}>Edit</button>{' '}
             <button onClick={() => deleteHabit(habit.id)}>Delete</button>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,6 +42,7 @@ def test_create_event_and_list_events():
             "success": True,
             "latitude": 1.0,
             "longitude": 2.0,
+            "note": "Feeling great",
         },
     )
     assert event_response.status_code == 200
@@ -52,6 +53,7 @@ def test_create_event_and_list_events():
     event = next(e for e in response.json() if e["id"] == event_id)
     assert event["latitude"] == 1.0
     assert event["longitude"] == 2.0
+    assert event["note"] == "Feeling great"
 
 
 def test_create_event_invalid_habit():
@@ -127,7 +129,7 @@ def test_export_data():
     habit_id = habit_resp.json()["id"]
     event_resp = client.post(
         "/events",
-        json={"habit_id": habit_id, "success": False},
+        json={"habit_id": habit_id, "success": False, "note": "x"},
     )
     event_id = event_resp.json()["id"]
 
@@ -135,7 +137,7 @@ def test_export_data():
     assert response.status_code == 200
     data = response.json()
     assert any(h["id"] == habit_id for h in data["habits"])
-    assert any(e["id"] == event_id for e in data["events"])
+    assert any(e["id"] == event_id and e["note"] == "x" for e in data["events"])
 
 
 def test_delete_event():
@@ -166,7 +168,7 @@ def test_export_delete_import_round_trip():
     habit = client.post("/habits", json={"name": "Import Habit"}).json()
     event = client.post(
         "/events",
-        json={"habit_id": habit["id"], "success": True},
+        json={"habit_id": habit["id"], "success": True, "note": "note"},
     ).json()
 
     export_resp = client.get("/export")
@@ -192,4 +194,4 @@ def test_export_delete_import_round_trip():
     events_after = client.get("/events").json()
 
     assert any(h["id"] == habit["id"] for h in habits_after)
-    assert any(e["id"] == event["id"] for e in events_after)
+    assert any(e["id"] == event["id"] and e["note"] == "note" for e in events_after)


### PR DESCRIPTION
## Summary
- update README to mention logging UI
- add note field to Event model
- prompt for optional note in frontend logging
- provide quick-switcher dropdown for habits
- test note in events and export/import

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6841b48901c88326b39356777fc379d9