### PR TITLE
Add docker-compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+node_modules
+__pycache__
+pytest.ini
+tests
+*.db
+data
+*.pyc

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This script starts both the FastAPI server on port 8080 and the Vite dev server 
 
 ## Docker
 
-To build and run the production container:
+To build and run the production container manually:
 
 ```sh
 docker build -t resistor .
@@ -36,6 +36,24 @@ docker run -p 8080:8080 resistor
 
 The image installs the Python requirements, installs the Node packages to build
 the frontend and finally launches the API with `uvicorn`.
+
+### Docker Compose
+
+A `docker-compose.yml` is included for convenience. It builds the image (or pulls
+it from Docker Hub when the `IMAGE` environment variable is set) and mounts the
+local `data/` directory so the SQLite database persists between runs.
+
+```sh
+docker compose up --build
+```
+
+To use a prebuilt image from Docker Hub instead of building locally:
+
+```sh
+export IMAGE=yourdockerhubuser/resistor:latest
+docker compose pull
+docker compose up -d
+```
 
 # Roadmap
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+services:
+  app:
+    image: ${IMAGE:-resistor:latest}
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/app/data
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a `docker-compose.yml` for easier deployment
- ignore unnecessary files during docker build
- document docker-compose usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6841b75ad7008326b14c8b3634d8aa97