### PR TITLE
Add GPS capture toggle

### DIFF
--- a/backend/resistor/database.py
+++ b/backend/resistor/database.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from sqlmodel import create_engine, SQLModel, Session
 
+from .models import Settings
+
 DATA_PATH = Path("data")
 DATA_PATH.mkdir(exist_ok=True)
 engine = create_engine(f"sqlite:///{DATA_PATH / 'resistor.db'}", echo=True)
@@ -10,6 +12,11 @@ def init_db():
     """Recreate database tables to ensure schema matches models."""
     SQLModel.metadata.drop_all(engine)
     SQLModel.metadata.create_all(engine)
+    # ensure default settings row exists
+    with Session(engine) as session:
+        if session.get(Settings, 1) is None:
+            session.add(Settings(id=1, capture_location=True))
+            session.commit()
 
 
 def get_session():

--- a/backend/resistor/models.py
+++ b/backend/resistor/models.py
@@ -20,3 +20,9 @@ class Event(SQLModel, table=True):
     latitude: float | None = None
     longitude: float | None = None
     note: str | None = None
+
+
+class Settings(SQLModel, table=True):
+    """Application-wide configuration."""
+    id: int | None = Field(default=1, primary_key=True)
+    capture_location: bool = Field(default=True)

--- a/backend/resistor/schemas.py
+++ b/backend/resistor/schemas.py
@@ -42,3 +42,7 @@ class ExportBundle(BaseModel):
     """Payload used for full data export/import."""
     habits: list[HabitRead]
     events: list[EventRead]
+
+
+class SettingsSchema(BaseModel):
+    capture_location: bool

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -161,6 +161,35 @@ def test_delete_event_not_found():
     assert response.status_code == 404
 
 
+def test_settings_endpoint_and_gps_disable():
+    init_db()
+
+    # default settings should return True
+    resp = client.get("/settings")
+    assert resp.status_code == 200
+    assert resp.json()["capture_location"] is True
+
+    # disable gps
+    resp = client.patch("/settings", json={"capture_location": False})
+    assert resp.status_code == 200
+    assert resp.json()["capture_location"] is False
+
+    habit = client.post("/habits", json={"name": "GPS"}).json()
+    ev_resp = client.post(
+        "/events",
+        json={
+            "habit_id": habit["id"],
+            "success": True,
+            "latitude": 12.3,
+            "longitude": 45.6,
+        },
+    )
+    assert ev_resp.status_code == 200
+    data = ev_resp.json()
+    assert data["latitude"] is None
+    assert data["longitude"] is None
+
+
 def test_export_delete_import_round_trip():
     init_db()
 


### PR DESCRIPTION
## Summary
- add `Settings` model and DB init helper
- expose `/settings` API to modify capture_location
- respect capture_location when creating events
- add capture toggle to frontend
- test new `/settings` endpoint and GPS disabling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6841bcb2f2288326927383a1a2ec602f