### PR TITLE
Improve frontend styling

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom/client';
+import './style.css';
 
 function AnalyticsTable() {
   const [rows, setRows] = useState([]);
@@ -174,18 +175,18 @@ function App() {
   }
 
   return (
-    <div>
+    <div className="container">
       <h1>Resistor</h1>
-      <label style={{ display: 'block', marginBottom: '1em' }}>
+      <label className="capture-toggle">
         <input
           type="checkbox"
           checked={captureLocation}
           onChange={toggleCapture}
-        />{' '}
+        />
         Capture Location
       </label>
       {habits.length > 0 && (
-        <div style={{ marginBottom: '1em' }}>
+        <div className="quick-actions">
           <select
             value={activeHabit || ''}
             onChange={(e) => setActiveHabit(Number(e.target.value))}
@@ -195,76 +196,76 @@ function App() {
                 {h.name}
               </option>
             ))}
-          </select>{' '}
-          <button onClick={() => logEvent(activeHabit, true)}>Resist</button>{' '}
+          </select>
+          <button onClick={() => logEvent(activeHabit, true)}>Resist</button>
           <button onClick={() => logEvent(activeHabit, false)}>Slip</button>
         </div>
       )}
-      <form onSubmit={createHabit} style={{ marginBottom: '1em' }}>
+      <form onSubmit={createHabit} className="habit-form">
         <input
           placeholder="Name"
           value={form.name}
           onChange={(e) => setForm({ ...form, name: e.target.value })}
           required
-        />{' '}
+        />
         <input
           placeholder="Description"
           value={form.description}
           onChange={(e) => setForm({ ...form, description: e.target.value })}
-        />{' '}
+        />
         <input
           type="color"
           value={form.color}
           onChange={(e) => setForm({ ...form, color: e.target.value })}
-        />{' '}
+        />
         <input
           placeholder="Icon"
           value={form.icon}
           onChange={(e) => setForm({ ...form, icon: e.target.value })}
-        />{' '}
+        />
         <button type="submit">Add Habit</button>
       </form>
 
       {editId && (
-        <form onSubmit={updateHabit} style={{ marginBottom: '1em' }}>
+        <form onSubmit={updateHabit} className="habit-form">
           <input
             placeholder="Name"
             value={editForm.name}
             onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
             required
-          />{' '}
+          />
           <input
             placeholder="Description"
             value={editForm.description}
             onChange={(e) =>
               setEditForm({ ...editForm, description: e.target.value })
             }
-          />{' '}
+          />
           <input
             type="color"
             value={editForm.color}
             onChange={(e) => setEditForm({ ...editForm, color: e.target.value })}
-          />{' '}
+          />
           <input
             placeholder="Icon"
             value={editForm.icon}
             onChange={(e) => setEditForm({ ...editForm, icon: e.target.value })}
-          />{' '}
-          <button type="submit">Save</button>{' '}
+          />
+          <button type="submit">Save</button>
           <button type="button" onClick={() => setEditId(null)}>
             Cancel
           </button>
         </form>
       )}
-      <ul>
+      <ul className="habit-list">
         {habits.map((habit) => (
           <li key={habit.id}>
             {habit.icon && <span>{habit.icon} </span>}
             <span style={{ color: habit.color || 'inherit' }}>{habit.name}</span>
-            {habit.description ? ` - ${habit.description}` : ''}{' '}
-            <button onClick={() => logEvent(habit.id, true)}>Resist</button>{' '}
-            <button onClick={() => logEvent(habit.id, false)}>Slip</button>{' '}
-            <button onClick={() => startEdit(habit)}>Edit</button>{' '}
+            {habit.description ? ` - ${habit.description}` : ''}
+            <button onClick={() => logEvent(habit.id, true)}>Resist</button>
+            <button onClick={() => logEvent(habit.id, false)}>Slip</button>
+            <button onClick={() => startEdit(habit)}>Edit</button>
           <button onClick={() => deleteHabit(habit.id)}>Delete</button>
         </li>
       ))}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,0 +1,126 @@
+body {
+  font-family: system-ui, sans-serif;
+  line-height: 1.5;
+  margin: 0;
+  padding: 1rem;
+  background: #f5f5f5;
+  color: #333;
+}
+
+#root {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.container {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.quick-actions select {
+  flex: 1 1 150px;
+}
+
+.quick-actions button {
+  flex: 1 1 80px;
+}
+
+h1 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+label,
+form {
+  margin-bottom: 1rem;
+  display: block;
+}
+
+input,
+select,
+button {
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+input,
+select {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-right: 0.5rem;
+}
+
+button {
+  border: none;
+  border-radius: 4px;
+  background: #333;
+  color: #fff;
+  cursor: pointer;
+}
+
+button + button {
+  margin-left: 0.5rem;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem 0;
+}
+
+li {
+  background: #fff;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+li button {
+  margin-left: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+th,
+td {
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 0.5rem;
+  }
+  input,
+  select,
+  button {
+    width: 100%;
+    margin-right: 0;
+    margin-bottom: 0.5rem;
+  }
+  li {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  li button {
+    margin-left: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- overhaul React UI with container, quick-action section and forms
- add global stylesheet for a modern look and responsive layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68437fe657a88326af903368ad394332