### PR TITLE
Add safe database initialization and regression test

### DIFF
--- a/backend/resistor/database.py
+++ b/backend/resistor/database.py
@@ -8,15 +8,25 @@ DATA_PATH.mkdir(exist_ok=True)
 engine = create_engine(f"sqlite:///{DATA_PATH / 'resistor.db'}", echo=True)
 
 
-def init_db():
-    """Recreate database tables to ensure schema matches models."""
-    SQLModel.metadata.drop_all(engine)
+def init_db_safe() -> None:
+    """Create database tables if they do not already exist."""
     SQLModel.metadata.create_all(engine)
     # ensure default settings row exists
     with Session(engine) as session:
         if session.get(Settings, 1) is None:
             session.add(Settings(id=1, capture_location=True))
             session.commit()
+
+
+def init_db_destructive() -> None:
+    """Drop and recreate all tables.
+
+    Intended for use in tests and fixtures that require a clean database
+    state. Production code should prefer :func:`init_db_safe`.
+    """
+
+    SQLModel.metadata.drop_all(engine)
+    init_db_safe()
 
 
 def get_session():

--- a/backend/resistor/main.py
+++ b/backend/resistor/main.py
@@ -3,7 +3,7 @@ from fastapi.encoders import jsonable_encoder
 from sqlmodel import select
 from datetime import datetime, timedelta
 
-from .database import init_db, get_session
+from .database import init_db_safe, get_session
 from .models import Habit, Event, Settings
 from .schemas import (
     HabitCreate,
@@ -27,7 +27,7 @@ def healthz():
 
 @app.on_event("startup")
 def on_startup():
-    init_db()
+    init_db_safe()
 
 
 @app.get("/settings", response_model=SettingsSchema)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,22 @@
+from sqlmodel import Session
+
+from resistor.database import init_db_destructive, init_db_safe, engine
+from resistor.models import Habit
+
+
+def test_init_db_safe_preserves_data():
+    init_db_destructive()
+
+    with Session(engine) as session:
+        habit = Habit(name="Persistent")
+        session.add(habit)
+        session.commit()
+        habit_id = habit.id
+
+    init_db_safe()
+    with Session(engine) as session:
+        assert session.get(Habit, habit_id) is not None
+
+    init_db_safe()
+    with Session(engine) as session:
+        assert session.get(Habit, habit_id) is not None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 from resistor.main import app
-from resistor.database import init_db
+from resistor.database import init_db_destructive
 
 client = TestClient(app)
 
@@ -12,7 +12,7 @@ def test_healthz():
 
 
 def test_create_and_list_habit():
-    init_db()
+    init_db_destructive()
     payload = {
         "name": "Test",
         "description": "Example desc",
@@ -33,7 +33,7 @@ def test_create_and_list_habit():
 
 
 def test_create_event_and_list_events():
-    init_db()
+    init_db_destructive()
     habit = client.post("/habits", json={"name": "Event Habit"}).json()
     event_response = client.post(
         "/events",
@@ -57,7 +57,7 @@ def test_create_event_and_list_events():
 
 
 def test_create_event_invalid_habit():
-    init_db()
+    init_db_destructive()
     response = client.post(
         "/events", json={"habit_id": 999999, "success": True}
     )
@@ -65,7 +65,7 @@ def test_create_event_invalid_habit():
 
 
 def test_update_habit():
-    init_db()
+    init_db_destructive()
     habit = client.post("/habits", json={"name": "Old"}).json()
 
     resp = client.patch(
@@ -82,7 +82,7 @@ def test_update_habit():
 
 
 def test_reorder_habits():
-    init_db()
+    init_db_destructive()
     h1 = client.post("/habits", json={"name": "One"}).json()
     h2 = client.post("/habits", json={"name": "Two"}).json()
 
@@ -95,7 +95,7 @@ def test_reorder_habits():
 
 
 def test_archive_habit():
-    init_db()
+    init_db_destructive()
     habit = client.post("/habits", json={"name": "Archivable"}).json()
 
     resp = client.patch(f"/habits/{habit['id']}", json={"archived": True})
@@ -110,7 +110,7 @@ def test_archive_habit():
 
 
 def test_delete_habit():
-    init_db()
+    init_db_destructive()
     habit = client.post("/habits", json={"name": "To Remove"}).json()
     client.post("/events", json={"habit_id": habit["id"], "success": True})
 
@@ -124,7 +124,7 @@ def test_delete_habit():
 
 
 def test_export_data():
-    init_db()
+    init_db_destructive()
     habit_resp = client.post("/habits", json={"name": "Export Habit"})
     habit_id = habit_resp.json()["id"]
     event_resp = client.post(
@@ -141,7 +141,7 @@ def test_export_data():
 
 
 def test_delete_event():
-    init_db()
+    init_db_destructive()
     habit = client.post("/habits", json={"name": "Delete Habit"}).json()
     event = client.post(
         "/events",
@@ -156,13 +156,13 @@ def test_delete_event():
 
 
 def test_delete_event_not_found():
-    init_db()
+    init_db_destructive()
     response = client.delete("/events/9999")
     assert response.status_code == 404
 
 
 def test_settings_endpoint_and_gps_disable():
-    init_db()
+    init_db_destructive()
 
     # default settings should return True
     resp = client.get("/settings")
@@ -191,7 +191,7 @@ def test_settings_endpoint_and_gps_disable():
 
 
 def test_export_delete_import_round_trip():
-    init_db()
+    init_db_destructive()
 
     # Create unique data to export
     habit = client.post("/habits", json={"name": "Import Habit"}).json()
@@ -210,7 +210,7 @@ def test_export_delete_import_round_trip():
 
     engine.dispose()
     Path(engine.url.database).unlink()
-    init_db()
+    init_db_destructive()
 
     # Verify DB is empty
     assert client.get("/habits").json() == []
@@ -227,7 +227,7 @@ def test_export_delete_import_round_trip():
 
 
 def test_encrypted_export_round_trip_and_wrong_passphrase():
-    init_db()
+    init_db_destructive()
 
     habit = client.post("/habits", json={"name": "Secret"}).json()
     client.post("/events", json={"habit_id": habit["id"], "success": True})
@@ -242,7 +242,7 @@ def test_encrypted_export_round_trip_and_wrong_passphrase():
 
     engine.dispose()
     Path(engine.url.database).unlink()
-    init_db()
+    init_db_destructive()
 
     fail = client.post("/import", params={"passphrase": "wrong"}, json=encrypted)
     assert fail.status_code == 400
@@ -252,7 +252,7 @@ def test_encrypted_export_round_trip_and_wrong_passphrase():
 
 
 def test_analytics_counts():
-    init_db()
+    init_db_destructive()
 
     h1 = client.post("/habits", json={"name": "H1"}).json()
     h2 = client.post("/habits", json={"name": "H2"}).json()


### PR DESCRIPTION
## Summary
- add a production-safe `init_db_safe` that preserves existing data and expose a destructive helper for tests
- switch the FastAPI startup and API tests to use the safe/destructive helpers appropriately
- add regression coverage ensuring data survives repeated safe initialization calls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f632a301ac8326a3e56f82c186bc4a