### PR TITLE
Time-of-day drill-down on Insights

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,8 +290,7 @@ coexist on disk; each mode only cleans its own files.
 ## Open GitHub Issues
 
 - #35 — App icon design
-- #36 — Dark mode audit
-- #37 — Accessibility pass
+- #37 — Accessibility pass (in progress — comprehensive VoiceOver/Dynamic Type sweep)
 
 ## Remaining Work (v1.0)
 

--- a/Resistor.xcodeproj/project.pbxproj
+++ b/Resistor.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		A1000015000000000000001A /* DataExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000015000000000000000A /* DataExporter.swift */; };
 		B2000001000000000000001A /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000001000000000000000A /* TestHelpers.swift */; };
 		B2000002000000000000001A /* InsightsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000002000000000000000A /* InsightsViewModelTests.swift */; };
+		B2000099000000000000001A /* TimeOfDayDrillDownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000099000000000000000A /* TimeOfDayDrillDownTests.swift */; };
 		B2000003000000000000001A /* TemptationEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000003000000000000000A /* TemptationEventTests.swift */; };
 		B2000004000000000000001A /* HabitsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000004000000000000000A /* HabitsViewModelTests.swift */; };
 		B2000005000000000000001A /* LogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000005000000000000000A /* LogViewModelTests.swift */; };
@@ -93,6 +94,7 @@
 		B2000000000000000000000A /* ResistorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ResistorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2000001000000000000000A /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		B2000002000000000000000A /* InsightsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModelTests.swift; sourceTree = "<group>"; };
+		B2000099000000000000000A /* TimeOfDayDrillDownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeOfDayDrillDownTests.swift; sourceTree = "<group>"; };
 		B2000003000000000000000A /* TemptationEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemptationEventTests.swift; sourceTree = "<group>"; };
 		B2000004000000000000000A /* HabitsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HabitsViewModelTests.swift; sourceTree = "<group>"; };
 		B2000005000000000000000A /* LogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewModelTests.swift; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 			children = (
 				B2000001000000000000000A /* TestHelpers.swift */,
 				B2000002000000000000000A /* InsightsViewModelTests.swift */,
+				B2000099000000000000000A /* TimeOfDayDrillDownTests.swift */,
 				B2000003000000000000000A /* TemptationEventTests.swift */,
 				B2000004000000000000000A /* HabitsViewModelTests.swift */,
 				B2000005000000000000000A /* LogViewModelTests.swift */,
@@ -428,6 +431,7 @@
 			files = (
 				B2000001000000000000001A /* TestHelpers.swift in Sources */,
 				B2000002000000000000001A /* InsightsViewModelTests.swift in Sources */,
+				B2000099000000000000001A /* TimeOfDayDrillDownTests.swift in Sources */,
 				B2000003000000000000001A /* TemptationEventTests.swift in Sources */,
 				B2000004000000000000001A /* HabitsViewModelTests.swift in Sources */,
 				B2000005000000000000001A /* LogViewModelTests.swift in Sources */,

--- a/Resistor/ViewModels/InsightsViewModel.swift
+++ b/Resistor/ViewModels/InsightsViewModel.swift
@@ -194,6 +194,28 @@ final class InsightsViewModel {
         return (0..<24).map { ($0, distribution[$0] ?? 0) }
     }
 
+    /// Hourly counts restricted to a single time-of-day window, returned in the
+    /// period's defined hour order (Night wraps midnight: 21…23, 0…4). Reads
+    /// `cachedEventsInRange` so habit + range filtering is honored, and the
+    /// per-hour counts sum to that period's overview bar.
+    func hourlyDistribution(for period: TimeOfDayPeriod) -> [(hour: Int, count: Int)] {
+        let events = cachedEventsInRange
+        var distribution: [Int: Int] = [:]
+        for hour in period.hours {
+            distribution[hour] = 0
+        }
+
+        let periodHours = Set(period.hours)
+        for event in events {
+            let hour = event.hourOfDay
+            if periodHours.contains(hour) {
+                distribution[hour, default: 0] += 1
+            }
+        }
+
+        return period.hours.map { ($0, distribution[$0] ?? 0) }
+    }
+
     // MARK: - Outcome Breakdown
 
     func outcomeBreakdown() -> [(outcome: TemptationEvent.Outcome, count: Int)] {
@@ -325,6 +347,47 @@ final class InsightsViewModel {
 
     var topLocation: String? {
         locationDistribution().first?.location
+    }
+}
+
+/// A time-of-day window on the Insights "Time of Day" chart. Mirrors
+/// `TemptationEvent.timeOfDayPeriod` (Morning 05–11, Afternoon 12–16,
+/// Evening 17–20, Night 21–04). `hours` is intentionally ordered for display:
+/// Night wraps midnight (21…23, 0…4), so it is NOT numerically sorted.
+enum TimeOfDayPeriod: String, CaseIterable {
+    case morning
+    case afternoon
+    case evening
+    case night
+
+    var displayName: String {
+        switch self {
+        case .morning: return "Morning"
+        case .afternoon: return "Afternoon"
+        case .evening: return "Evening"
+        case .night: return "Night"
+        }
+    }
+
+    /// Hours belonging to this window, in display order.
+    var hours: [Int] {
+        switch self {
+        case .morning: return [5, 6, 7, 8, 9, 10, 11]
+        case .afternoon: return [12, 13, 14, 15, 16]
+        case .evening: return [17, 18, 19, 20]
+        case .night: return [21, 22, 23, 0, 1, 2, 3, 4]
+        }
+    }
+
+    /// Maps a `timeOfDayDistribution` period string (e.g. "Evening") back to a case.
+    init?(periodString: String) {
+        switch periodString {
+        case "Morning": self = .morning
+        case "Afternoon": self = .afternoon
+        case "Evening": self = .evening
+        case "Night": self = .night
+        default: return nil
+        }
     }
 }
 

--- a/Resistor/Views/HabitsView.swift
+++ b/Resistor/Views/HabitsView.swift
@@ -186,6 +186,9 @@ struct HabitsView: View {
                     .foregroundStyle(.tertiary)
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint("Opens habit editor")
         .contentShape(Rectangle())
         .onTapGesture {
             vm.prepareEditHabit(habit)
@@ -273,7 +276,7 @@ struct HabitsView: View {
                                     try? modelContext.save()
                                 }
                                 .accessibilityLabel(color.name)
-                                .accessibilityAddTraits(isSelected ? .isSelected : [])
+                                .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
                         }
                     }
                 }
@@ -459,7 +462,7 @@ struct HabitsView: View {
                                     vm.selectedColorHex = color.hex
                                 }
                                 .accessibilityLabel(color.name)
-                                .accessibilityAddTraits(vm.selectedColorHex == color.hex ? .isSelected : [])
+                                .accessibilityAddTraits(vm.selectedColorHex == color.hex ? [.isButton, .isSelected] : .isButton)
                         }
                     }
                     .padding(.vertical, 8)
@@ -483,7 +486,7 @@ struct HabitsView: View {
                                     vm.selectedIconName = icon
                                 }
                                 .accessibilityLabel(icon.replacingOccurrences(of: ".fill", with: "").replacingOccurrences(of: ".", with: " "))
-                                .accessibilityAddTraits(vm.selectedIconName == icon ? .isSelected : [])
+                                .accessibilityAddTraits(vm.selectedIconName == icon ? [.isButton, .isSelected] : .isButton)
                         }
                     }
                     .padding(.vertical, 8)

--- a/Resistor/Views/HabitsView.swift
+++ b/Resistor/Views/HabitsView.swift
@@ -51,6 +51,8 @@ struct HabitsView: View {
                     }) {
                         Image(systemName: "plus")
                     }
+                    .accessibilityLabel("Add Habit")
+                    .accessibilityIdentifier("addHabitButton")
                 }
             }
         }

--- a/Resistor/Views/HistoryView.swift
+++ b/Resistor/Views/HistoryView.swift
@@ -164,6 +164,8 @@ struct HistoryView: View {
             }
         }
         .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint("Opens event details")
         .contentShape(Rectangle())
         .onTapGesture {
             selectedEvent = event

--- a/Resistor/Views/HistoryView.swift
+++ b/Resistor/Views/HistoryView.swift
@@ -109,8 +109,10 @@ struct HistoryView: View {
             // Event details
             VStack(alignment: .leading, spacing: 4) {
                 HStack {
-                    if let habit = event.habit {
-                        Text(habit.name)
+                    // When the list is scoped to one habit, the screen title
+                    // already names it — showing it on every row is redundant.
+                    if habit == nil, let eventHabit = event.habit {
+                        Text(eventHabit.name)
                             .font(.subheadline)
                             .fontWeight(.medium)
                     }

--- a/Resistor/Views/InsightsView.swift
+++ b/Resistor/Views/InsightsView.swift
@@ -123,6 +123,10 @@ struct InsightsView: View {
                 }
                 .frame(height: 12)
                 .clipShape(Capsule())
+                // Purely decorative: the legend directly below conveys the same
+                // counts as readable text, so the bar would only add a confusing
+                // empty element for VoiceOver.
+                .accessibilityHidden(true)
 
                 // Legend
                 HStack(alignment: .top, spacing: 12) {
@@ -182,6 +186,7 @@ struct InsightsView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8) {
                     ForEach(Array(vm.habits.enumerated()), id: \.element.id) { index, habit in
+                        let isSelected = vm.selectedHabitIndex == index
                         Button(action: {
                             vm.selectedHabitIndex = index
                         }) {
@@ -195,12 +200,14 @@ struct InsightsView: View {
                             .padding(.vertical, 9)
                             .background(
                                 Capsule()
-                                    .fill(vm.selectedHabitIndex == index
+                                    .fill(isSelected
                                           ? (Color(hex: habit.colorHex ?? "#007AFF") ?? .blue)
                                           : Color(.secondarySystemBackground))
                             )
-                            .foregroundStyle(vm.selectedHabitIndex == index ? .white : .primary)
+                            .foregroundStyle(isSelected ? .white : .primary)
                         }
+                        .accessibilityLabel(habit.name)
+                        .accessibilityAddTraits(isSelected ? .isSelected : [])
                     }
                 }
             }

--- a/Resistor/Views/InsightsView.swift
+++ b/Resistor/Views/InsightsView.swift
@@ -8,6 +8,12 @@ struct InsightsView: View {
 
     @State private var viewModel: InsightsViewModel?
 
+    /// Non-nil = the "Time of Day" card is expanded into the hourly drill-down
+    /// for that period; nil = the 4-period overview. At most one at a time.
+    @State private var expandedPeriod: TimeOfDayPeriod?
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         NavigationStack {
             Group {
@@ -353,18 +359,205 @@ struct InsightsView: View {
 
     @ViewBuilder
     private func timeOfDayChart(_ vm: InsightsViewModel) -> some View {
+        let barColor = Color(hex: vm.selectedHabit?.colorHex ?? "#007AFF") ?? .blue
+
+        SectionCard(
+            title: timeOfDayTitle,
+            accessory: expandedPeriod.map { _ in AnyView(collapseControl) }
+        ) {
+            if let period = expandedPeriod {
+                expandedTimeOfDayChart(vm, period: period, barColor: barColor)
+            } else {
+                overviewTimeOfDayChart(vm, barColor: barColor)
+            }
+        }
+    }
+
+    private var timeOfDayTitle: String {
+        if let period = expandedPeriod {
+            return "Time of Day · \(period.displayName)"
+        }
+        return "Time of Day"
+    }
+
+    private var collapseControl: some View {
+        Button {
+            setExpandedPeriod(nil)
+            UIAccessibility.post(notification: .announcement, argument: "Showing time-of-day overview")
+        } label: {
+            Image(systemName: "chevron.up.circle")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Collapse hourly breakdown")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    /// Applies an `expandedPeriod` change, animating only when Reduce Motion is off.
+    private func setExpandedPeriod(_ period: TimeOfDayPeriod?) {
+        if reduceMotion {
+            expandedPeriod = period
+        } else {
+            withAnimation(.easeInOut(duration: 0.25)) {
+                expandedPeriod = period
+            }
+        }
+    }
+
+    // MARK: Time of Day — Overview (4 periods)
+
+    @ViewBuilder
+    private func overviewTimeOfDayChart(_ vm: InsightsViewModel, barColor: Color) -> some View {
         let data = vm.timeOfDayDistribution()
 
-        SectionCard(title: "Time of Day") {
-            Chart(data, id: \.period) { item in
-                BarMark(
-                    x: .value("Period", item.period),
-                    y: .value("Count", item.count)
-                )
-                .foregroundStyle(Color(hex: vm.selectedHabit?.colorHex ?? "#007AFF") ?? .blue)
-            }
-            .frame(height: 150)
+        Chart(data, id: \.period) { item in
+            BarMark(
+                x: .value("Period", item.period),
+                y: .value("Count", item.count)
+            )
+            .foregroundStyle(barColor)
         }
+        .frame(height: 150)
+        .chartOverlay { proxy in
+            GeometryReader { geo in
+                Rectangle()
+                    .fill(Color.clear)
+                    .contentShape(Rectangle())
+                    .gesture(
+                        SpatialTapGesture()
+                            .onEnded { value in
+                                guard let plotFrame = proxy.plotFrame else { return }
+                                let origin = geo[plotFrame].origin
+                                let xPosition = value.location.x - origin.x
+                                if let periodString: String = proxy.value(atX: xPosition),
+                                   let period = TimeOfDayPeriod(periodString: periodString) {
+                                    setExpandedPeriod(period)
+                                    UIAccessibility.post(
+                                        notification: .announcement,
+                                        argument: "Showing hourly breakdown for \(period.displayName)"
+                                    )
+                                }
+                            }
+                    )
+            }
+        }
+        // The bars themselves aren't natively accessible; we hide the chart and
+        // expose explicit button elements below for VoiceOver.
+        .accessibilityHidden(true)
+        overviewAccessibilityElements(data)
+    }
+
+    /// Hidden-but-accessible buttons mirroring each overview bar, since Swift
+    /// Charts bars aren't VoiceOver elements on their own.
+    @ViewBuilder
+    private func overviewAccessibilityElements(_ data: [(period: String, count: Int)]) -> some View {
+        VStack(spacing: 0) {
+            ForEach(data, id: \.period) { item in
+                Color.clear
+                    .frame(height: 0)
+                    .accessibilityElement()
+                    .accessibilityLabel("\(item.period), \(eventCountPhrase(item.count))")
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityHint("Double tap to show hourly breakdown.")
+                    .accessibilityAction {
+                        if let period = TimeOfDayPeriod(periodString: item.period) {
+                            setExpandedPeriod(period)
+                            UIAccessibility.post(
+                                notification: .announcement,
+                                argument: "Showing hourly breakdown for \(period.displayName)"
+                            )
+                        }
+                    }
+            }
+        }
+        .frame(height: 0)
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: Time of Day — Expanded (hourly drill-down)
+
+    @ViewBuilder
+    private func expandedTimeOfDayChart(_ vm: InsightsViewModel, period: TimeOfDayPeriod, barColor: Color) -> some View {
+        let data = vm.hourlyDistribution(for: period)
+        // Ordered category strings so Charts renders Night left-to-right
+        // (21,22,23,0,1,2,3,4) without re-sorting numerically.
+        let orderedLabels = data.map { String($0.hour) }
+        // Floor the y-domain at 0…1 so an all-zero window (e.g. Night with no
+        // events in range) still renders a baseline and a "0/1" y-axis rather
+        // than an empty void that reads as broken. The flat baseline is the
+        // intended "all zero" answer (per spec), but it needs a frame to read
+        // as a chart at all.
+        let yMax = max(data.map(\.count).max() ?? 0, 1)
+
+        Chart(data, id: \.hour) { item in
+            BarMark(
+                x: .value("Hour", String(item.hour)),
+                y: .value("Count", item.count)
+            )
+            .foregroundStyle(barColor)
+        }
+        .chartXScale(domain: orderedLabels)
+        .chartYScale(domain: 0...yMax)
+        .frame(height: 150)
+        .chartYAxis {
+            AxisMarks(values: .automatic(desiredCount: 3)) { value in
+                AxisGridLine()
+                AxisValueLabel {
+                    if let count = value.as(Int.self) {
+                        Text("\(count)")
+                            .font(.caption2)
+                    }
+                }
+            }
+        }
+        .chartXAxis {
+            AxisMarks { value in
+                AxisValueLabel {
+                    if let label = value.as(String.self) {
+                        Text(label)
+                            .font(.caption2)
+                    }
+                }
+            }
+        }
+        // Tapping hourly bars does nothing; expose each hour for VoiceOver only.
+        .accessibilityHidden(true)
+        expandedAccessibilityElements(data)
+    }
+
+    @ViewBuilder
+    private func expandedAccessibilityElements(_ data: [(hour: Int, count: Int)]) -> some View {
+        VStack(spacing: 0) {
+            ForEach(data, id: \.hour) { item in
+                Color.clear
+                    .frame(height: 0)
+                    .accessibilityElement()
+                    .accessibilityLabel("\(Self.twelveHourClock(item.hour)), \(eventCountPhrase(item.count))")
+            }
+        }
+        .frame(height: 0)
+        .accessibilityElement(children: .contain)
+    }
+
+    /// "4 events" / "1 event" / "0 events" with correct pluralization.
+    private func eventCountPhrase(_ count: Int) -> String {
+        count == 1 ? "1 event" : "\(count) events"
+    }
+
+    /// 24-hour value → full 12-hour clock form for VoiceOver: 0→"12 AM",
+    /// 13→"1 PM", 12→"12 PM", 18→"6 PM".
+    private static func twelveHourClock(_ hour: Int) -> String {
+        let period = hour < 12 ? "AM" : "PM"
+        let twelve: Int
+        if hour % 12 == 0 {
+            twelve = 12
+        } else {
+            twelve = hour % 12
+        }
+        return "\(twelve) \(period)"
     }
 
     @ViewBuilder

--- a/Resistor/Views/InsightsView.swift
+++ b/Resistor/Views/InsightsView.swift
@@ -613,7 +613,9 @@ struct StatCard: View {
                 .fontWeight(.bold)
                 .foregroundStyle(valueColor)
                 .lineLimit(1)
-                .minimumScaleFactor(0.7)
+                // Floor low enough that the longest value ("Afternoon") still
+                // fits a half-width card at large Dynamic Type without clipping.
+                .minimumScaleFactor(0.5)
 
             Text(subtitle)
                 .font(.caption2)

--- a/Resistor/Views/LogView.swift
+++ b/Resistor/Views/LogView.swift
@@ -41,6 +41,9 @@ struct LogView: View {
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
         vm.logTemptation(contextTags: Array(tagsToLog))
         vm.triggerConfirmation()
+        // The confirmation banner is a transient visual; VoiceOver won't read it
+        // on its own, so post an explicit announcement of the result.
+        UIAccessibility.post(notification: .announcement, argument: "Temptation logged")
     }
 
     private func startHold(_ vm: LogViewModel) {
@@ -218,6 +221,7 @@ struct LogView: View {
                         .foregroundStyle(.secondary)
                         .padding(.top, 28)
                         .opacity(1.0 - dimAmount)
+                        .accessibilityLabel("\(habit.todayEventsCount) logged today for \(habit.name)")
                 }
 
                 // Larger flexible space below the cluster than above it keeps the
@@ -377,8 +381,18 @@ struct LogView: View {
         .zIndex(isHolding ? 1 : 0)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Log temptation for \(habit.name)")
+        .accessibilityValue("\(habit.todayEventsCount) logged today")
         .accessibilityHint("Tap or hold to log a temptation")
         .accessibilityAddTraits(.isButton)
+        // VoiceOver users can't perform the swipe-to-switch-habit drag, so expose
+        // the carousel's next/previous as named actions on the card itself (the
+        // visible arrows are also labelled, but only render with >1 habit).
+        .accessibilityActions {
+            if vm.habits.count > 1 {
+                Button("Next habit") { vm.selectNextHabit() }
+                Button("Previous habit") { vm.selectPreviousHabit() }
+            }
+        }
         .padding(.horizontal, 24)
         .offset(x: cardDragOffset)
         .contentShape(RoundedRectangle(cornerRadius: 20))

--- a/Resistor/Views/LogView.swift
+++ b/Resistor/Views/LogView.swift
@@ -490,7 +490,11 @@ struct LogView: View {
                         .padding(.vertical, 6)
                         .background(
                             RoundedRectangle(cornerRadius: 8)
-                                .fill(isSelected ? accentColor : Color.gray.opacity(0.2))
+                                // Semantic fill (not a fixed translucent gray) so
+                                // the unselected chip keeps adequate presence in
+                                // both light and dark mode rather than fading into
+                                // the pure-black dark canvas.
+                                .fill(isSelected ? accentColor : Color(.secondarySystemFill))
                         )
                         .foregroundStyle(isSelected ? .white : .primary)
                 }

--- a/Resistor/Views/LogView.swift
+++ b/Resistor/Views/LogView.swift
@@ -173,11 +173,11 @@ struct LogView: View {
 
         ZStack {
             VStack(spacing: 0) {
-                // Smaller top spacer biases the hero cluster toward the optical
-                // center (slightly above geometric middle) rather than stranding
-                // it low with a large void under the title.
+                // Top spacer is bounded but smaller than the bottom flexible
+                // space, so the hero cluster sits just above optical center and
+                // the void under the navigation title is tightened.
                 Spacer(minLength: 0)
-                    .frame(maxHeight: 56)
+                    .frame(maxHeight: 28)
 
                 // Current habit card cluster — pager sits directly above the
                 // card it controls so the relationship reads as one unit.
@@ -185,35 +185,44 @@ struct LogView: View {
                     if vm.habits.count > 1 {
                         habitCarousel(vm)
                             .opacity(1.0 - dimAmount)
-                            .padding(.bottom, 20)
+                            .padding(.bottom, 16)
                     }
 
                     habitCard(habit, vm: vm)
 
-                    Text("Tap or hold to log")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                        .padding(.top, 12)
+                    Label("Tap or hold to log", systemImage: "hand.tap")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 14)
                         .opacity(1.0 - dimAmount)
 
                     // Context tags (pre-select before logging)
                     if !contextTags.isEmpty {
-                        tagChips
-                            .padding(.top, 20)
-                            .opacity(1.0 - dimAmount)
+                        VStack(spacing: 10) {
+                            Text("Add context (optional)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, 24)
+
+                            tagChips
+                        }
+                        .padding(.top, 28)
+                        .opacity(1.0 - dimAmount)
                     }
-                }
-
-                Spacer(minLength: 0)
-
-                // Today's count
-                if let habit = vm.selectedHabit {
+                    // Today's count sits a fixed distance below the chips so it
+                    // reads as part of the hero cluster instead of stranding at
+                    // the very bottom of the screen.
                     Text("Today: \(habit.todayEventsCount) logged")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
-                        .padding(.bottom, 24)
+                        .padding(.top, 28)
                         .opacity(1.0 - dimAmount)
                 }
+
+                // Larger flexible space below the cluster than above it keeps the
+                // composed group centered slightly high, with no low void.
+                Spacer(minLength: 0)
             }
 
             // Dimming vignette behind the card during hold
@@ -279,6 +288,11 @@ struct LogView: View {
         let habitColor = Color(hex: habit.colorHex ?? "#007AFF") ?? .blue
         let cardScale = reduceMotion ? 1.0 : 1.0 + (holdProgress * 0.08)
         let glowPulseIntensity: CGFloat = glowPulsing ? 1.0 : 0.5
+        // Resting affordance: a steady habit-color border so the card reads as
+        // the primary tappable action (not a passive info panel), and gives the
+        // surface figure/ground separation on the pure-black dark canvas. The
+        // hold effect's progress/glow rings render on top of this.
+        let restBorderOpacity: CGFloat = isHolding ? 0 : 0.55
 
         VStack(spacing: 16) {
             // Icon — gets its own glow during hold
@@ -312,10 +326,18 @@ struct LogView: View {
             RoundedRectangle(cornerRadius: 20)
                 .fill(Color(.secondarySystemBackground))
                 .overlay(
-                    // Background tint intensifies during hold
+                    // Background tint intensifies during hold. Resting tint is a
+                    // touch stronger than before so the surface separates from
+                    // the canvas (notably the pure-black dark background).
                     RoundedRectangle(cornerRadius: 20)
-                        .fill(habitColor.opacity(0.1 + holdProgress * 0.2))
+                        .fill(habitColor.opacity(0.15 + holdProgress * 0.2))
                 )
+        )
+        .overlay(
+            // Resting affordance border — steady habit-color stroke that signals
+            // the card is the interactive log control and frames the surface.
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(habitColor.opacity(restBorderOpacity), lineWidth: 1.5)
         )
         .overlay(
             // Progress trim ring — shows exactly how far along the hold is

--- a/Resistor/Views/OnboardingView.swift
+++ b/Resistor/Views/OnboardingView.swift
@@ -23,6 +23,7 @@ struct OnboardingView: View {
                         .font(.body)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
                         .padding(.horizontal)
                 }
                 .padding(.top, 40)
@@ -74,6 +75,9 @@ struct OnboardingView: View {
                                     }
                                 }
                                 .padding(.horizontal)
+                                // Vertical room so the selection ring isn't
+                                // clipped by the scroll view's content bounds.
+                                .padding(.vertical, 4)
                             }
                         }
 
@@ -106,6 +110,9 @@ struct OnboardingView: View {
                                     }
                                 }
                                 .padding(.horizontal)
+                                // Vertical room so the selection border isn't
+                                // clipped by the scroll view's content bounds.
+                                .padding(.vertical, 4)
                             }
                         }
                     }

--- a/Resistor/Views/OnboardingView.swift
+++ b/Resistor/Views/OnboardingView.swift
@@ -71,7 +71,7 @@ struct OnboardingView: View {
                                                 vm.selectedColorHex = color.hex
                                             }
                                             .accessibilityLabel(color.name)
-                                            .accessibilityAddTraits(vm.selectedColorHex == color.hex ? .isSelected : [])
+                                            .accessibilityAddTraits(vm.selectedColorHex == color.hex ? [.isButton, .isSelected] : .isButton)
                                     }
                                 }
                                 .padding(.horizontal)
@@ -106,7 +106,7 @@ struct OnboardingView: View {
                                                 vm.selectedIconName = icon
                                             }
                                             .accessibilityLabel(icon.replacingOccurrences(of: ".fill", with: "").replacingOccurrences(of: ".", with: " "))
-                                            .accessibilityAddTraits(vm.selectedIconName == icon ? .isSelected : [])
+                                            .accessibilityAddTraits(vm.selectedIconName == icon ? [.isButton, .isSelected] : .isButton)
                                     }
                                 }
                                 .padding(.horizontal)
@@ -138,6 +138,7 @@ struct OnboardingView: View {
                                 .cornerRadius(12)
                         }
                         .disabled(!vm.canCreateHabit)
+                        .accessibilityHint(vm.canCreateHabit ? "" : "Enter a habit name first")
 
                         Button(action: {
                             if vm.skipOnboarding() {
@@ -148,6 +149,7 @@ struct OnboardingView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                         }
+                        .accessibilityHint("You can add habits later from the Habits tab")
                     }
                     .padding(.horizontal)
                     .padding(.bottom, 32)

--- a/ResistorTests/TimeOfDayDrillDownTests.swift
+++ b/ResistorTests/TimeOfDayDrillDownTests.swift
@@ -1,0 +1,269 @@
+import XCTest
+import SwiftData
+@testable import Resistor
+
+/// Tests for the Time-of-Day drill-down logic added to InsightsViewModel:
+/// `TimeOfDayPeriod` (hours / displayName / init?(periodString:)) and
+/// `hourlyDistribution(for:)`.
+@MainActor
+final class TimeOfDayDrillDownTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestHelpers.makeModelContainer()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        container = nil
+        context = nil
+    }
+
+    // MARK: - TimeOfDayPeriod.hours
+
+    func testMorningHours() {
+        XCTAssertEqual(TimeOfDayPeriod.morning.hours, [5, 6, 7, 8, 9, 10, 11])
+    }
+
+    func testAfternoonHours() {
+        XCTAssertEqual(TimeOfDayPeriod.afternoon.hours, [12, 13, 14, 15, 16])
+    }
+
+    func testEveningHours() {
+        XCTAssertEqual(TimeOfDayPeriod.evening.hours, [17, 18, 19, 20])
+    }
+
+    /// AC-5: Night must wrap midnight in display order, NOT be numerically sorted.
+    func testNightHoursWrapMidnightInDisplayOrder() {
+        XCTAssertEqual(TimeOfDayPeriod.night.hours, [21, 22, 23, 0, 1, 2, 3, 4])
+        // Explicitly assert it is NOT numeric-sorted.
+        XCTAssertNotEqual(TimeOfDayPeriod.night.hours, TimeOfDayPeriod.night.hours.sorted())
+    }
+
+    /// Every hour 0...23 belongs to exactly one period, with no overlaps —
+    /// guarantees the drill-down windows partition the day so per-hour counts
+    /// can sum back to the overview without double-counting (AC-1).
+    func testAllHoursPartitionedExactlyOnce() {
+        let all = TimeOfDayPeriod.allCases.flatMap { $0.hours }
+        XCTAssertEqual(all.count, 24, "Periods must cover exactly 24 hour-slots with no overlap")
+        XCTAssertEqual(Set(all), Set(0..<24), "Periods must cover every hour 0...23 exactly once")
+    }
+
+    /// The enum's hour windows must agree with TemptationEvent.timeOfDayPeriod
+    /// (the classifier the overview bar uses). If these drift, drill-down sums
+    /// won't match the overview.
+    func testHoursAgreeWithEventTimeOfDayClassifier() {
+        let habit = TestHelpers.makeHabit()
+        let today = Calendar.current.startOfDay(for: Date())
+        for hour in 0..<24 {
+            let date = Calendar.current.date(byAdding: .hour, value: hour, to: today)!
+            let event = TestHelpers.makeEvent(habit: habit, occurredAt: date)
+            let classifierPeriod = event.timeOfDayPeriod
+            let owningPeriod = TimeOfDayPeriod.allCases.first { $0.hours.contains(hour) }
+            XCTAssertEqual(owningPeriod?.displayName, classifierPeriod,
+                           "Hour \(hour): enum owner \(String(describing: owningPeriod?.displayName)) != classifier \(classifierPeriod)")
+        }
+    }
+
+    // MARK: - init?(periodString:)
+
+    func testInitPeriodStringRoundTrips() {
+        XCTAssertEqual(TimeOfDayPeriod(periodString: "Morning"), .morning)
+        XCTAssertEqual(TimeOfDayPeriod(periodString: "Afternoon"), .afternoon)
+        XCTAssertEqual(TimeOfDayPeriod(periodString: "Evening"), .evening)
+        XCTAssertEqual(TimeOfDayPeriod(periodString: "Night"), .night)
+    }
+
+    func testInitPeriodStringRoundTripsThroughDisplayName() {
+        for period in TimeOfDayPeriod.allCases {
+            XCTAssertEqual(TimeOfDayPeriod(periodString: period.displayName), period)
+        }
+    }
+
+    /// init? must accept exactly the strings emitted by timeOfDayDistribution()/
+    /// TemptationEvent.timeOfDayPeriod.
+    func testInitPeriodStringAcceptsDistributionStrings() {
+        let habit = TestHelpers.makeHabit()
+        context.insert(habit)
+        let vm = InsightsViewModel(modelContext: context)
+        for (period, _) in vm.timeOfDayDistribution() {
+            XCTAssertNotNil(TimeOfDayPeriod(periodString: period),
+                            "Distribution emitted '\(period)' that init?(periodString:) rejects")
+        }
+    }
+
+    func testInitPeriodStringRejectsGarbage() {
+        XCTAssertNil(TimeOfDayPeriod(periodString: "garbage"))
+        XCTAssertNil(TimeOfDayPeriod(periodString: ""))
+        XCTAssertNil(TimeOfDayPeriod(periodString: "morning"))   // wrong case
+        XCTAssertNil(TimeOfDayPeriod(periodString: "Mid-day"))
+    }
+
+    // MARK: - hourlyDistribution(for:) — shape & order
+
+    func testHourlyDistributionReturnsOneEntryPerHourInOrder() {
+        let habit = TestHelpers.makeHabit()
+        context.insert(habit)
+        try? context.save()
+        let vm = InsightsViewModel(modelContext: context)
+
+        for period in TimeOfDayPeriod.allCases {
+            let dist = vm.hourlyDistribution(for: period)
+            XCTAssertEqual(dist.map(\.hour), period.hours,
+                           "\(period.displayName) bars not one-per-hour in period order")
+        }
+    }
+
+    /// AC-5: a zero-event period still expands to all-zero hourly bars, one per hour.
+    func testZeroEventPeriodYieldsAllZeroBars() {
+        let habit = TestHelpers.makeHabit()
+        context.insert(habit)
+        try? context.save()
+        let vm = InsightsViewModel(modelContext: context)
+        vm.selectedTimeRange = .week
+
+        let dist = vm.hourlyDistribution(for: .night)
+        XCTAssertEqual(dist.map(\.hour), TimeOfDayPeriod.night.hours)
+        XCTAssertTrue(dist.allSatisfy { $0.count == 0 })
+        XCTAssertEqual(dist.count, TimeOfDayPeriod.night.hours.count)
+    }
+
+    // MARK: - hourlyDistribution(for:) — bucketing
+
+    func testEventsAssignedToCorrectHourBucket() {
+        let habit = TestHelpers.makeHabit()
+        context.insert(habit)
+        let today = Calendar.current.startOfDay(for: Date())
+
+        // 2 events at 08:00, 1 event at 10:00 (both Morning)
+        for _ in 0..<2 {
+            let d = Calendar.current.date(byAdding: .hour, value: 8, to: today)!
+            context.insert(TestHelpers.makeEvent(habit: habit, occurredAt: d))
+        }
+        let tenAM = Calendar.current.date(byAdding: .hour, value: 10, to: today)!
+        context.insert(TestHelpers.makeEvent(habit: habit, occurredAt: tenAM))
+        try? context.save()
+
+        let vm = InsightsViewModel(modelContext: context)
+        vm.selectedTimeRange = .week
+        let dist = vm.hourlyDistribution(for: .morning)
+
+        XCTAssertEqual(dist.first(where: { $0.hour == 8 })?.count, 2)
+        XCTAssertEqual(dist.first(where: { $0.hour == 10 })?.count, 1)
+        // Other morning hours stay zero
+        XCTAssertEqual(dist.first(where: { $0.hour == 5 })?.count, 0)
+        XCTAssertEqual(dist.first(where: { $0.hour == 11 })?.count, 0)
+    }
+
+    /// AC-5 ordering with real data: a 23:00 event and a 01:00 event both land in
+    /// Night, appearing in wrap order (21…23 before 0…4).
+    func testNightBucketingAcrossMidnight() {
+        let habit = TestHelpers.makeHabit()
+        context.insert(habit)
+        let today = Calendar.current.startOfDay(for: Date())
+
+        let elevenPM = Calendar.current.date(byAdding: .hour, value: 23, to: today)!
+        context.insert(TestHelpers.makeEvent(habit: habit, occurredAt: elevenPM))
+        let oneAM = Calendar.current.date(byAdding: .hour, value: 1, to: today)!
+        context.insert(TestHelpers.makeEvent(habit: habit, occurredAt: oneAM))
+        try? context.save()
+
+        let vm = InsightsViewModel(modelContext: context)
+        vm.selectedTimeRange = .week
+        let dist = vm.hourlyDistribution(for: .night)
+
+        XCTAssertEqual(dist.first(where: { $0.hour == 23 })?.count, 1)
+        XCTAssertEqual(dist.first(where: { $0.hour == 1 })?.count, 1)
+        // Index of 23 must come before index of 1 (wrap order, not numeric).
+        let idx23 = dist.firstIndex(where: { $0.hour == 23 })!
+        let idx1 = dist.firstIndex(where: { $0.hour == 1 })!
+        XCTAssertLessThan(idx23, idx1)
+    }
+
+    // MARK: - AC-1: hourly counts sum to the overview period count
+
+    func testHourlyCountsSumToOverviewPeriodCount() {
+        let habit = TestHelpers.makeHabit()
+        context.insert(habit)
+        let today = Calendar.current.startOfDay(for: Date())
+
+        // Spread events across all four windows, including a midnight-wrap night event.
+        let hours = [6, 8, 8, 13, 16, 18, 20, 23, 2, 4]
+        for h in hours {
+            let d = Calendar.current.date(byAdding: .hour, value: h, to: today)!
+            context.insert(TestHelpers.makeEvent(habit: habit, occurredAt: d))
+        }
+        try? context.save()
+
+        let vm = InsightsViewModel(modelContext: context)
+        vm.selectedTimeRange = .week
+
+        let overview = vm.timeOfDayDistribution()
+        for period in TimeOfDayPeriod.allCases {
+            let overviewCount = overview.first { $0.period == period.displayName }?.count ?? -1
+            let hourlySum = vm.hourlyDistribution(for: period).reduce(0) { $0 + $1.count }
+            XCTAssertEqual(hourlySum, overviewCount,
+                           "\(period.displayName): hourly sum \(hourlySum) != overview \(overviewCount)")
+        }
+    }
+
+    // MARK: - AC-4: respects active range, recomputes (never stale)
+
+    func testHourlyDistributionRespectsActiveRange() {
+        let habit = TestHelpers.makeHabit()
+        context.insert(habit)
+        let calendar = Calendar.current
+        let now = Date()
+        let today = calendar.startOfDay(for: now)
+
+        // Morning event today (in week + month range)
+        let todayMorning = calendar.date(byAdding: .hour, value: 8, to: today)!
+        context.insert(TestHelpers.makeEvent(habit: habit, occurredAt: todayMorning))
+
+        // Morning event 15 days ago (only in month range)
+        let oldDay = calendar.date(byAdding: .day, value: -15, to: today)!
+        let oldMorning = calendar.date(byAdding: .hour, value: 8, to: oldDay)!
+        context.insert(TestHelpers.makeEvent(habit: habit, occurredAt: oldMorning))
+        try? context.save()
+
+        let vm = InsightsViewModel(modelContext: context)
+
+        vm.selectedTimeRange = .week
+        XCTAssertEqual(vm.hourlyDistribution(for: .morning).first(where: { $0.hour == 8 })?.count, 1,
+                       "Week range should only see today's morning event")
+
+        // Switching range must recompute, not serve stale data.
+        vm.selectedTimeRange = .month
+        XCTAssertEqual(vm.hourlyDistribution(for: .morning).first(where: { $0.hour == 8 })?.count, 2,
+                       "Month range should see both morning events")
+    }
+
+    func testHourlyDistributionRespectsSelectedHabit() {
+        let habitA = TestHelpers.makeHabit(name: "A", createdAt: Date(timeIntervalSince1970: 1))
+        let habitB = TestHelpers.makeHabit(name: "B", createdAt: Date(timeIntervalSince1970: 2))
+        context.insert(habitA)
+        context.insert(habitB)
+        let today = Calendar.current.startOfDay(for: Date())
+        let eightAM = Calendar.current.date(byAdding: .hour, value: 8, to: today)!
+
+        // 1 morning event on A, 3 morning events on B
+        context.insert(TestHelpers.makeEvent(habit: habitA, occurredAt: eightAM))
+        for _ in 0..<3 {
+            context.insert(TestHelpers.makeEvent(habit: habitB, occurredAt: eightAM))
+        }
+        try? context.save()
+
+        let vm = InsightsViewModel(modelContext: context)
+        vm.selectedTimeRange = .week
+
+        // habits sorted by createdAt: index 0 = A, index 1 = B
+        vm.selectedHabitIndex = 0
+        XCTAssertEqual(vm.hourlyDistribution(for: .morning).first(where: { $0.hour == 8 })?.count, 1)
+
+        vm.selectedHabitIndex = 1
+        XCTAssertEqual(vm.hourlyDistribution(for: .morning).first(where: { $0.hour == 8 })?.count, 3,
+                       "Switching habit must recompute hourly bars for the new habit")
+    }
+}

--- a/ResistorUITests/SnapshotTests.swift
+++ b/ResistorUITests/SnapshotTests.swift
@@ -61,6 +61,14 @@ final class SnapshotTests: XCTestCase {
                 scroll.swipeDown(velocity: .fast)
             }
 
+            // Time-of-Day drill-down: expand a period into its hourly bars and
+            // capture both a typical window (Evening, 4 bars) and the densest
+            // window (Night, 8 bars across midnight) so the label-thinning and
+            // across-midnight order can be reviewed visually. The whole period
+            // bar's x-band is the tap target (chartOverlay hit test), so we tap
+            // the chart plot at the period's horizontal position.
+            captureTimeOfDayDrilldown(app, scroll: scroll, sfx: sfx)
+
             // 3. History — pushed from Insights via "View History".
             let history = app.buttons["View History"]
             if history.waitForExistence(timeout: 3) {
@@ -104,6 +112,55 @@ final class SnapshotTests: XCTestCase {
                 scroll.swipeUp(velocity: .slow)
                 snapshot(app, name: "04-Habits-c\(sfx)")
             }
+        }
+    }
+
+    /// Scrolls the Time of Day card into view and drives the drill-down by
+    /// tapping the chart plot at a given period's horizontal band, capturing the
+    /// resulting expanded (hourly) state. Captures Evening (4 bars) and Night
+    /// (8 bars wrapping midnight) so the dense-label case can be judged, then
+    /// collapses via the chevron control.
+    private func captureTimeOfDayDrilldown(_ app: XCUIApplication, scroll: XCUIElement, sfx: String) {
+        // Bring the Time of Day card into the middle of the screen. It sits
+        // below the Daily Trend chart; one slow swipe from the top reveals it
+        // without pushing it off the top edge, so the expanded chart stays
+        // fully visible in the capture.
+        scroll.swipeUp(velocity: .slow)
+
+        // The real expand interaction is a `chartOverlay` spatial-tap hit test
+        // on the chart plot. The mirrored accessibility buttons are zero-height
+        // proxies whose frames don't track the chart, so we tap the chart plot
+        // directly by normalized position within the scroll view. The four
+        // period bands run left→right (Morning, Afternoon, Evening, Night); dy
+        // sits on the bars, above the x-axis labels.
+        func tapPeriod(dx: CGFloat) {
+            scroll.coordinate(withNormalizedOffset: CGVector(dx: dx, dy: 0.63)).tap()
+        }
+
+        // Evening — the simple 4-bar case (3rd of 4 bands).
+        tapPeriod(dx: 0.60)
+        if app.buttons["Collapse hourly breakdown"].waitForExistence(timeout: 2) {
+            snapshot(app, name: "02-Insights-tod-evening\(sfx)")
+            collapseTimeOfDay(app)
+        }
+
+        // Night — the dense 8-bar across-midnight case (21,22,23,0,1,2,3,4),
+        // 4th of 4 bands.
+        tapPeriod(dx: 0.82)
+        if app.buttons["Collapse hourly breakdown"].waitForExistence(timeout: 2) {
+            snapshot(app, name: "02-Insights-tod-night\(sfx)")
+            collapseTimeOfDay(app)
+        }
+
+        // Restore scroll position for any later legs.
+        scroll.swipeDown(velocity: .fast)
+        scroll.swipeDown(velocity: .fast)
+    }
+
+    private func collapseTimeOfDay(_ app: XCUIApplication) {
+        let chevron = app.buttons["Collapse hourly breakdown"]
+        if chevron.waitForExistence(timeout: 2) {
+            chevron.tap()
         }
     }
 

--- a/ResistorUITests/SnapshotTests.swift
+++ b/ResistorUITests/SnapshotTests.swift
@@ -79,6 +79,19 @@ final class SnapshotTests: XCTestCase {
             app.tabBars.buttons["Habits"].tap()
             snapshot(app, name: "04-Habits\(sfx)")
 
+            // 5. New Habit sheet & 6. Edit Habit sheet — both use the same form,
+            // whose color/icon pickers carry the selection-ring rendering we want
+            // to verify isn't clipped. Captured before scrolling the list so the
+            // add button and the first habit row are both on screen.
+            captureHabitFormSheet(
+                app, open: { app.buttons["addHabitButton"].tap() },
+                title: "New Habit", namePrefix: "05-NewHabit", sfx: sfx
+            )
+            captureHabitFormSheet(
+                app, open: { app.staticTexts["Sugar"].tap() },
+                title: "Edit Habit", namePrefix: "06-EditHabit", sfx: sfx
+            )
+
             // Scrolled captures so the Settings / Context Tags sections below
             // the fold can be reviewed. An inset-grouped List surfaces as a
             // collectionView/table rather than a plain scrollView.
@@ -92,6 +105,27 @@ final class SnapshotTests: XCTestCase {
                 snapshot(app, name: "04-Habits-c\(sfx)")
             }
         }
+    }
+
+    /// Opens the add/edit habit form sheet, captures the top (name + Color
+    /// picker) and a scrolled view (Icon picker + Preview), then cancels back
+    /// out. `open` performs the gesture that presents the sheet; `title` is the
+    /// sheet's navigation-bar title used to confirm it appeared and to dismiss.
+    private func captureHabitFormSheet(
+        _ app: XCUIApplication,
+        open: () -> Void,
+        title: String,
+        namePrefix: String,
+        sfx: String
+    ) {
+        open()
+        guard app.navigationBars[title].waitForExistence(timeout: 3) else { return }
+        snapshot(app, name: "\(namePrefix)\(sfx)")
+        // A full-sheet Form scrolls with a window swipe; reveal the Icon picker.
+        app.swipeUp(velocity: .slow)
+        snapshot(app, name: "\(namePrefix)-b\(sfx)")
+        let cancel = app.navigationBars[title].buttons["Cancel"]
+        if cancel.exists { cancel.tap() }
     }
 
     /// Captures a full-screen screenshot and attaches it under `name`.

--- a/docs/design.md
+++ b/docs/design.md
@@ -82,6 +82,56 @@ Edge cases:
 - No events: empty state prompting to log from Log tab
 - High event counts: charts stay legible
 
+### Flow 3a: Time-of-Day Drill-Down
+
+The Time of Day chart presents four coarse periods (Morning, Afternoon, Evening,
+Night) as the legible overview. The user may expand one period in place to inspect
+its hour-by-hour breakdown. Expansion is in-place on the Insights screen; it does
+**not** push a new screen (honors the max-one-level-deep navigation rule).
+
+1. On the Insights screen, the Time of Day chart shows the four-period bar chart.
+2. User selects a period (e.g. Evening).
+3. The chart expands in place to show hourly bars for only that period's hours
+   (Evening = 17:00, 18:00, 19:00, 20:00).
+4. User selects the same period again, or selects a collapse affordance, to return
+   to the four-period overview.
+5. Selecting a different period replaces the current expansion with that period's
+   hours.
+
+Period-to-hour mapping (derived from `occurredAt`, matching
+`TemptationEvent.timeOfDayPeriod`):
+
+| Period | Hours (24h) |
+|--------|-------------|
+| Morning | 05, 06, 07, 08, 09, 10, 11 |
+| Afternoon | 12, 13, 14, 15, 16 |
+| Evening | 17, 18, 19, 20 |
+| Night | 21, 22, 23, 00, 01, 02, 03, 04 |
+
+Edge cases:
+- Night wraps midnight (21:00–04:00). Hourly bars for Night are ordered 21→04, not
+  numerically, so the window reads as a continuous block.
+- A period with zero events still expands; its hourly bars all read zero. No empty
+  state is shown for an expanded period — the zero bars are the answer.
+- The expansion respects the active habit and time range (7/30 days); changing
+  either while expanded **recomputes** the hourly bars for the still-selected period
+  and keeps it expanded (it does **not** collapse). Rationale below in
+  "Filter changes while expanded."
+- Hour count is keyed to the device's selected habit and range filter only — no
+  cross-habit aggregation.
+
+**Filter changes while expanded (decided).** When the user changes the habit
+selector or the 7/30-day range while a period is expanded, the chart **stays
+expanded on the same period and recomputes its hourly bars** — it does not collapse
+to the overview. Rationale: a user inspecting "Evening" is mid-question
+("when in the evening?"); switching habit or range is almost always a follow-up of
+that same question ("…and for my other habit?"). Collapsing would force a re-tap to
+resume the comparison and lose the user's place. The expansion is a view state keyed
+to a period identity (Morning/Afternoon/Evening/Night), not to a specific dataset,
+so it survives a data refresh cleanly. The bars animate their height to the new
+counts (see Motion); no stale data is ever shown because the hourly query reads the
+same `cachedEventsInRange` the overview does.
+
 ### Flow 4: Context Logging
 
 Context tags are user-defined and managed via the `ContextTag` SwiftData model. Tags are displayed as selectable chips directly on the Log screen (pre-selected before logging), rather than in a post-log sheet.
@@ -124,9 +174,197 @@ Context tags are user-defined and managed via the `ContextTag` SwiftData model. 
 - Summary stats: this period vs previous, peak time, peak day
 - Outcome breakdown (stacked bar + resisted %)
 - Daily trend chart (bar chart)
-- Time of day chart (bar chart)
+- Time of day chart (bar chart) — four periods; a selected period expands in place
+  to hourly bars (see Time-of-Day Drill-Down below)
 - Day of week chart (bar chart)
 - "View History" navigation link
+
+#### Time-of-Day Drill-Down (use cases)
+
+The four-period Time of Day chart is the default, legible overview. Event data is
+sparse (typically tens of events per user), so 24 hourly bars up front would read
+as noise. A user who notices a spike in one period can expand that period to hourly
+detail on demand — fine resolution appears only where the user signaled interest.
+
+This requires **no data-model or schema change**. Hourly granularity is derived
+from the existing `TemptationEvent.occurredAt` timestamp (`hourOfDay` /
+`timeOfDayPeriod` already exist; `InsightsViewModel.hourlyDistribution()` already
+returns per-hour counts). No new field, no CloudKit migration.
+
+**UC-1 — Expand a period to hourly detail.**
+As someone reviewing patterns, I want to expand a time period into its hours so
+that I can see which hour within a spike is driving it.
+Acceptance criteria:
+- The four-period chart is the default state on entering Insights.
+- Selecting a period replaces that period's single bar with one bar per hour in
+  that period's window (per the mapping in Flow 3a).
+- The hourly bars are labeled by hour and cover exactly the selected period's hours
+  — no more, no fewer.
+- Counts in the hourly bars sum to the count shown for that period in the overview
+  (for the same habit and time range).
+
+**UC-2 — Collapse back to the overview.**
+As someone reviewing patterns, I want to return to the four-period overview so that
+I can compare periods again after inspecting one.
+Acceptance criteria:
+- A collapse affordance returns the chart to the four-period overview.
+- The same chart remains on the Insights screen throughout; no navigation push
+  occurs, and the back/tab state is unchanged.
+
+**UC-3 — Switch the inspected period.**
+As someone reviewing patterns, I want to expand a different period without first
+collapsing so that comparison is quick.
+Acceptance criteria:
+- Selecting a different period while one is expanded replaces the hourly bars with
+  the newly selected period's hours.
+- At most one period is expanded at a time.
+
+**UC-4 — Drill-down reflects active filters.**
+As someone reviewing patterns, I want the hourly view to honor my selected habit
+and time range so that the detail matches the overview it came from.
+Acceptance criteria:
+- Hourly bars reflect only the currently selected habit and the active 7/30-day
+  range.
+- Changing the habit selector or time range while a period is expanded recomputes
+  the hourly bars for the still-selected period (or collapses to overview — a
+  ux-designer decision; either is acceptable so long as no stale data is shown).
+
+**UC-5 — Sparse / empty data.**
+As someone with few logged events, I want the drill-down to behave predictably so
+that an empty hour isn't mistaken for a bug.
+Acceptance criteria:
+- A period with zero events still expands; all its hourly bars read zero.
+- The Night period's hourly bars are ordered 21:00 → 04:00 (wrapping midnight), not
+  numerically, so the window reads as one continuous block.
+- No separate empty state is shown for an expanded period; zero bars are the
+  result.
+
+#### Time-of-Day Drill-Down (interaction and visual spec)
+
+This is the build-ready spec for the drill-down. It refines the `timeOfDayChart`
+function inside the existing `SectionCard(title: "Time of Day")` in
+`Views/InsightsView.swift`. No new screen, no navigation push, no new data model.
+
+##### Placement and layout
+
+Everything lives inside the existing `SectionCard`. The card grows/shrinks in height
+as the chart swaps; the surrounding Insights `ScrollView` reflows naturally.
+
+The card has two stacked regions inside its existing 16pt-spaced `VStack`:
+
+1. **Header row** (replaces the plain `SectionCard` title for this one card). The
+   card is built with `SectionCard(title:)` as today, but uses the card's
+   `accessory` slot for a trailing collapse control when expanded:
+   - Title text: `"Time of Day"` in the overview state. When a period is expanded,
+     the title becomes `"Time of Day · Evening"` (middot-joined,
+     `Text("Time of Day") + Text(" · ") + Text(period)`), where the period segment
+     is `.foregroundStyle(.secondary)`. This anchors the user without a separate
+     breadcrumb row. The title uses the existing `.headline` style and is allowed to
+     wrap to two lines at large Dynamic Type (no `lineLimit(1)`).
+   - Accessory (expanded state only): a **collapse control** — an SF Symbol
+     `chevron.up.circle` button, `.font(.body)`, `.foregroundStyle(.secondary)`,
+     min 44×44pt tap target (pad to reach it). In the overview state the accessory
+     slot is empty.
+2. **Chart region** — the `Chart` itself, 150pt tall in both states (unchanged from
+   today, so the card does not jump in height between states; only the title and
+   x-axis change).
+
+##### States
+
+| State | Chart content | Header | Notes |
+|-------|---------------|--------|-------|
+| **Overview** (default) | 4 `BarMark`s: Morning, Afternoon, Evening, Night, habit color | Title `"Time of Day"`, no accessory | Identical to today's chart plus tap affordance |
+| **Expanded** (one period) | N `BarMark`s, one per hour in the period's window (4 Evening / 5 Afternoon / 7 Morning / 8 Night), habit color | Title `"Time of Day · {Period}"` + collapse chevron | Replaces the 4-bar overview entirely |
+| **Expanded, zero-data** | Same N hourly bars, all at height 0 (flat baseline, axis labels visible) | Same as Expanded | No separate empty copy. The flat axis is the answer. The card is **not** rendered at all when the whole habit/range `!vm.hasData` — that case is already handled upstream by `noDataView`, so the drill-down never shows for a habit with zero total events. |
+| **Range/habit change while expanded** | Bars animate height to recomputed counts for the same period | Unchanged (same period title) | Stays expanded; see Flow 3a "Filter changes while expanded" |
+| **Loading** | No dedicated spinner | — | Insights recompute is synchronous and instant from `cachedEventsInRange`; there is no async loading state for this card. The whole Insights screen already gates on `viewModel == nil` with a `ProgressView` upstream. |
+
+There is intentionally **no disabled state** and **no per-bar selected state** in the
+overview — every period bar is always tappable, including zero-count ones (a
+zero-count period expands to all-zero hourly bars, consistent with UC-5).
+
+##### Interaction model (gestures)
+
+- **Tap target = the whole period bar (and its full-height column), not a chevron.**
+  Implement with Swift Charts `.chartOverlay` + a `chartProxy` hit test that maps the
+  tap x-location to the nearest period via `proxy.value(atX:)`. The tappable region
+  is the full chart-plot height for that period's x-band, so a zero-count bar (which
+  has near-zero drawn height) is still easily tappable. No visible chevron on
+  individual bars — keeps the overview clean and legible per the "4-bar overview is
+  the legible default" goal.
+- **Tap a period (overview → expanded):** sets `expandedPeriod = .evening`. Chart
+  swaps to that period's hourly bars.
+- **Tap the same period again is NOT the collapse path.** Once expanded, the
+  individual hourly bars are not themselves a collapse target (tapping an hourly bar
+  does nothing — hourly is the resolution floor this pass). Collapse is an **explicit
+  control**: the `chevron.up.circle` accessory in the header. This avoids the
+  ambiguity of "did I tap the same period or a different one" when the overview bars
+  are no longer on screen.
+- **Tap a different period to swap:** only reachable from the overview. Because the
+  overview bars are replaced when expanded, swapping is a two-step gesture: collapse
+  (chevron) → tap the other period. This is deliberate: at most one period is
+  expanded, and the overview is the comparison surface. (A future pass may add a
+  compact period segmented control above the hourly chart to allow direct swap
+  without collapsing — explicitly out of scope here.)
+- State model: a single `@State private var expandedPeriod: TimeOfDayPeriod?` on
+  `InsightsView` (nil = overview). The implementer defines a small
+  `enum TimeOfDayPeriod: String { case morning, afternoon, evening, night }` with a
+  `displayName` and an ordered `hours: [Int]` array (Night = `[21,22,23,0,1,2,3,4]`,
+  NOT numeric sort).
+
+##### Hourly data source
+
+The implementer adds a windowed variant to `InsightsViewModel`, e.g.
+`hourlyDistribution(for period: TimeOfDayPeriod) -> [(hour: Int, count: Int)]`,
+returning one entry per hour in `period.hours`, **in that array's order** (so Night
+preserves 21→04). It reads the same `cachedEventsInRange` the overview uses, so it
+automatically honors the active habit and 7/30-day range. The per-hour counts must
+sum to that period's overview count (UC-1 acceptance criterion).
+
+##### Hour-axis labeling
+
+The x value for each `BarMark` is the **hour label string** (a plottable category),
+ordered by the `period.hours` array, so Night renders left-to-right 21,22,23,0,…,4
+without Charts re-sorting numerically. Use a `.value("Hour", label)` nominal axis.
+
+Label format — compact, no AM/PM clutter, fits 8 bars on phone width:
+
+- Visible axis labels use a **24-hour two-digit-free short form**: the bare hour
+  number, e.g. `5, 6, 7, …` for Morning and `21, 22, 23, 0, 1, 2, 3, 4` for Night.
+  No colons, no ":00", no "h". This is the most compact unambiguous label and matches
+  the clinical tone.
+- To prevent crowding at 8 bars (Night) on a narrow phone or at large Dynamic Type,
+  use `.chartXAxis { AxisMarks { ... AxisValueLabel().font(.caption2) } }` and allow
+  Charts to thin labels if needed. Do **not** rotate labels. If thinning still
+  crowds, label every other bar — but all 8 bars always render; only their text
+  labels may thin.
+- The accessibility (VoiceOver) label is the **full, unambiguous** form (12-hour with
+  AM/PM) — see Accessibility below — so the terse visual labels never cost clarity
+  for assistive tech.
+
+##### Color and highlight
+
+- Hourly bars use the **selected habit color**, identical to the overview bars:
+  `Color(hex: vm.selectedHabit?.colorHex ?? "#007AFF") ?? .blue`. Never a hardcoded
+  brand color. Dark mode is automatic because the surface is
+  `secondarySystemBackground` and the bar is the user's hex.
+- No separate "selected bar" highlight is needed because the overview bars are
+  replaced, not annotated. The only persistent indicator that you are drilled in is
+  the title suffix (`· Evening`) plus the collapse chevron.
+
+##### Exact copy
+
+| Element | String |
+|---------|--------|
+| Card title (overview) | `Time of Day` |
+| Card title (expanded) | `Time of Day · Morning` / `· Afternoon` / `· Evening` / `· Night` |
+| Period display names | `Morning`, `Afternoon`, `Evening`, `Night` (match existing) |
+| Hourly axis labels | bare hour numbers: `5`, `6` … `21`, `22`, `23`, `0`, `1` … `4` |
+| Collapse control | no text label; SF Symbol `chevron.up.circle` only |
+
+No empty-state copy, no "tap to expand" hint text (the bars are the affordance; a hint
+line would clutter the clinical layout). No motivational or emotional strings. No
+emoji.
 
 ### S3: Habits and Settings Screen
 
@@ -252,6 +490,8 @@ Dark mode is the default. Light mode must also work.
 | Horizontal drag | Habit card | Swipe between habits | 50pt commit, 30pt min start |
 | Swipe trailing | Habit row | Archive/Delete | System default |
 | Swipe trailing | Event row | Delete | System default |
+| Tap | Time of Day period bar (overview) | Expand that period to hourly bars | Full plot-height x-band hit test via `chartOverlay` + `chartProxy` |
+| Tap | Time of Day collapse chevron (expanded) | Collapse to four-period overview | 44×44pt min target |
 
 ### Drag Gesture (Habit Card)
 
@@ -303,7 +543,25 @@ Rules:
 | Banner appear/dismiss | Slide from top + fade | 0.3s easeInOut |
 | Habit card drag | Interactive spring | — |
 | Card snap-back | Spring | 0.3s |
+| Time of Day expand/collapse | Bars cross-fade + height change | 0.25s easeInOut |
+| Time of Day filter-change while expanded | Bar heights interpolate to new counts | 0.25s easeInOut |
 | Sheets, tabs, navigation | System default | System |
+
+#### Time-of-Day Drill-Down motion
+
+- **Expand/collapse:** wrap the `expandedPeriod` mutation in
+  `withAnimation(.easeInOut(duration: 0.25))`. The chart swaps its data; Swift Charts
+  animates bar height and the new/removed bars cross-fade. The `SectionCard` title
+  suffix and collapse chevron appear/disappear within the same animation. Because the
+  chart frame height is fixed at 150pt in both states, the card does not jolt — only
+  the bars and labels change.
+- **Filter change while expanded:** the recompute is animated identically (bars glide
+  to their new heights), reinforcing that it is the same period viewed with new data.
+- **Reduce Motion (required):** gate every animation above on `!reduceMotion`
+  (`@Environment(\.accessibilityReduceMotion)`). When Reduce Motion is on, mutate
+  `expandedPeriod` and the filter-driven data with **no** `withAnimation` wrapper —
+  the chart swaps instantly, no cross-fade, no height interpolation. This matches the
+  established Reduce Motion pattern (instant state change, no spring/slide).
 
 ### Confirmation Banner
 
@@ -559,6 +817,36 @@ Guidelines, not gates. No CI to enforce.
 - Habit cards, stat cards, chart containers grouped as single accessible elements
 - Custom labels for: log button ("Log temptation for [habit name]"), carousel arrows, intensity circles, outcome buttons
 
+#### Time-of-Day Drill-Down (VoiceOver)
+
+The chart bars are not natively accessible as individual elements, so provide an
+explicit accessibility representation rather than relying on the visual `Chart`.
+
+- **Overview bars.** Each period bar is one accessible element.
+  - Label: `"{Period}, {n} events"` — e.g. `"Evening, 12 events"`. Use `"1 event"`
+    singular, `"0 events"` for zero (not "no events").
+  - Trait: `.isButton`.
+  - Hint: `"Double tap to show hourly breakdown."`
+  - On activate: expands that period (same effect as the visual tap).
+- **Collapse control (expanded only).**
+  - Label: `"Collapse hourly breakdown"`.
+  - Trait: `.isButton`.
+  - On activate: returns to the four-period overview.
+- **Hourly bars (expanded).** Each hour is one accessible element, ordered the same
+  as the visual bars (Night = 9 PM → 4 AM).
+  - Label: full unambiguous 12-hour form + count:
+    `"{hour 12h with AM/PM}, {n} events"` — e.g. `"6 PM, 4 events"`, `"9 PM, 0 events"`,
+    `"12 AM, 1 event"`, `"5 AM, 0 events"`. The visual axis uses terse 24-hour numbers,
+    but VoiceOver always speaks the full form so there is no ambiguity for assistive
+    tech. Format with a fixed `DateFormatter` (`"h a"`) or a hand-rolled 12-hour map;
+    use `"event"` / `"events"` singular/plural correctly.
+  - Trait: none beyond static text — hourly bars are read-only (no drill below hour).
+- **State-change announcement.** On expand and on collapse, post a
+  `UIAccessibility.post(notification: .screenChanged, argument:)` (or
+  `.announcement`) with the text `"Showing hourly breakdown for {Period}"` on expand
+  and `"Showing time-of-day overview"` on collapse, so a VoiceOver user knows the
+  chart content swapped under them.
+
 ### Dynamic Type
 
 - All text uses SwiftUI text styles (no hardcoded sizes)
@@ -566,6 +854,11 @@ Guidelines, not gates. No CI to enforce.
 - Stat cards stack vertically at accessibility sizes
 - Context tag grid reflows
 - Intensity circles remain 44pt minimum
+- Time of Day card title (`"Time of Day · Evening"`) wraps to a second line at large
+  Dynamic Type — no `lineLimit(1)`, no fixed card height that would clip it
+- Hourly x-axis labels use `.caption2` and may thin (every other bar) at large sizes;
+  bars themselves never clip — the 150pt chart frame is fixed but the bars scale
+  within it
 - Test at: Default, Large, AX3, AX5
 
 ### Reduce Motion
@@ -574,6 +867,8 @@ When enabled:
 - Confirmation banner: crossfade instead of slide
 - Habit card drag: snap immediately instead of spring
 - Sheet presentation: system automatic
+- Time of Day expand/collapse and filter-driven recompute: instant chart swap, no
+  cross-fade or bar-height interpolation (no `withAnimation`)
 
 ### Color and Contrast
 
@@ -755,3 +1050,10 @@ Summary of all design decisions made during the design phase.
 | Banner timing | After all sheets dismiss, 4s with undo | Was hidden behind sheets; undo prevents accidental logs |
 | Default habit | User-settable via context menu | Core for fast logging |
 | Time zones | Store UTC, display local | Standard practice |
+| Time-of-day drill-down | Tap a period to expand to hourly bars in place | Sparse data makes 24 bars up front noise; detail on demand only |
+| Drill-down granularity floor | Hourly for first pass; half-hour deferred | Hourly is enough to locate a spike; finer resolution is "later" |
+| Drill-down navigation | In-place expansion, not a pushed screen | Honors max-one-level-deep rule |
+| Drill-down filter change while expanded | Recompute hourly bars, stay expanded (don't collapse) | Filter change is a follow-up to the same question; collapsing loses the user's place |
+| Drill-down collapse affordance | Explicit `chevron.up.circle` in card header; tapping hourly bars does nothing | Overview bars are gone when expanded, so "tap same to collapse" is ambiguous |
+| Drill-down tap target | Whole period bar's full-height x-band (chartOverlay hit test), not a chevron | Keeps the overview clean; zero-count bars stay tappable |
+| Hourly axis label format | Bare hour number (24h: `5`…`21,22,23,0`…`4`); VoiceOver speaks full 12h AM/PM | Most compact unambiguous visual label; assistive tech keeps full clarity |


### PR DESCRIPTION
## Summary
Adds drill-down to the Insights **Time of Day** card. Tap any of the 4 period bars (Morning/Afternoon/Evening/Night) to expand it **in place** into an hourly breakdown of that window; a header chevron collapses back. The coarse 4-period overview stays the default so sparse temptation data reads cleanly — hourly detail surfaces only where the user signals interest.

- **No navigation push** — in-place expansion respects the max-one-level-deep rule.
- **No schema/CloudKit change** — hourly counts derive from the existing `TemptationEvent.occurredAt`.
- Honors the active habit + 7/30-day range; recomputes and stays expanded on the same period when filters change.

## Changes
- **`InsightsViewModel`** — new `TimeOfDayPeriod` enum (Night ordered `21,22,23,0,1,2,3,4` across midnight, not numeric sort) + `hourlyDistribution(for:)` over `cachedEventsInRange`. Existing full-24h method untouched.
- **`InsightsView`** — overview↔expanded states, `chartOverlay` tap-to-expand, `chevron.up.circle` collapse, `easeInOut(0.25)` gated on Reduce Motion, explicit VoiceOver elements (period buttons w/ expand hint, full 12-hour hourly labels, expand/collapse announcements). Y-axis floored at `0...max(count,1)` so an all-zero window frames as a flat baseline instead of an empty void.
- **Tests** — 17 new unit tests in `TimeOfDayDrillDownTests.swift` (Night ordering w/ anti-sort guard, hour-window partition, sum-to-overview, zero-event bars, recompute on habit/range change). `SnapshotTests` extended to drive + capture the expanded (Evening) and dense (Night) states in light + dark.
- **`docs/design.md`** — Flow 3a, S2 interaction/visual spec, motion + accessibility notes.

## Testing
- `xcodebuild ... build` → **BUILD SUCCEEDED**
- `xcodebuild ... test` → **207/207 passing, 0 failures** (iPhone 17 Pro), no regressions.
- Visual pass (light + dark): Night's 8 across-midnight labels are not crowded and read 21→4 left-to-right; no card jolt between states; habit color consistent.

## Known items
- Seed data has no Night events in the 7-day range, so populated Night bars weren't screenshot-verified (labels + empty-state framing were). Optional future `UITestSeed` tweak.
- Large Dynamic Type (AX3+) label thinning relies on Charts' automatic behavior — not screenshot-verified (harness captures default size only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)