### PR TITLE
Add habit "+" button to Log screen toolbar

### DIFF
--- a/Resistor/Views/LogView.swift
+++ b/Resistor/Views/LogView.swift
@@ -116,6 +116,30 @@ struct LogView: View {
                 }
             }
             .navigationTitle("Log")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showAddHabitSheet = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                    .accessibilityLabel("Add Habit")
+                    .accessibilityIdentifier("addHabitButtonLog")
+                }
+            }
+        }
+        .sheet(isPresented: $showAddHabitSheet, onDismiss: {
+            if viewModel == nil {
+                viewModel = LogViewModel(
+                    modelContext: modelContext,
+                    defaultHabitId: userSettings.first?.defaultHabitId,
+                    locationManager: locationManager
+                )
+            } else {
+                viewModel?.fetchHabits()
+            }
+        }) {
+            AddHabitFromLogSheet(modelContext: modelContext)
         }
         .onAppear {
             if locationManager.authorizationStatus == .notDetermined {
@@ -157,19 +181,6 @@ struct LogView: View {
                     .font(.headline)
             }
             .buttonStyle(.borderedProminent)
-            .sheet(isPresented: $showAddHabitSheet, onDismiss: {
-                if viewModel == nil {
-                    viewModel = LogViewModel(
-                        modelContext: modelContext,
-                        defaultHabitId: userSettings.first?.defaultHabitId,
-                        locationManager: locationManager
-                    )
-                } else {
-                    viewModel?.fetchHabits()
-                }
-            }) {
-                AddHabitFromLogSheet(modelContext: modelContext)
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
Surfaces habit creation directly from the Log screen. Live device testing found that the only way to add a habit was to navigate to the Habits tab, which wasn't intuitive.

- Adds a `primaryAction` "+" toolbar button on the Log screen that presents the existing `AddHabitFromLogSheet`.
- Visible in both the empty state and the normal logging state.
- Consolidates the add-habit sheet to a single `NavigationStack`-level presentation so the toolbar button and the empty-state button share one `onDismiss`/viewModel-refresh path.

## Testing
- `xcodebuild ... -scheme Resistor build` → **BUILD SUCCEEDED**.
- Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)