### PR TITLE
Document Xcode MCP bridge and track widget/haptics/watch issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,23 @@ xcodebuild -project Resistor.xcodeproj \
 **No CI/CD.** Local builds only.
 **Test target:** `ResistorTests` — unit tests for ViewModels, Models, and Services.
 
+### Xcode MCP bridge (preferred when connected)
+
+An `xcode` MCP server (Apple's `xcrun mcpbridge`) is registered with Claude Code
+for this project, giving agents structured access to the **open** Xcode project —
+builds, test runs, and diagnostics as data rather than scraped `xcodebuild` log
+text. **When the `xcode` MCP tools are available, prefer them** for building,
+testing, and reading errors; fall back to the `xcodebuild` command above only
+when the bridge isn't connected.
+
+Requires, on the developer's machine: Xcode Settings → **Intelligence** →
+**Model Context Protocol** → **"Allow external agents to use Xcode tools"** is on,
+the Resistor project is **open in Xcode**, and the session was restarted after the
+server was added (MCP servers load at session start). If the `xcode` tools aren't
+present, assume one of those isn't satisfied and use `xcodebuild`. The bridge does
+**not** manage Signing & Capabilities or Developer-portal provisioning (App
+Groups, CloudKit) — those remain manual Xcode steps.
+
 ## Development Team (Agent Roster & Routing)
 
 Resistor is built by a roster of role subagents that mirror a software
@@ -291,6 +308,9 @@ coexist on disk; each mode only cleans its own files.
 
 - #35 — App icon design
 - #37 — Accessibility pass (in progress — comprehensive VoiceOver/Dynamic Type sweep)
+- #47 — Quick-log widget: device verification + App Group / CloudKit capability setup
+- #48 — No haptics firing on device (tap impact + hold Core Haptics both silent)
+- #49 — watchOS app: wrist-fast resisted-temptation logging (post-v1, companion to widget)
 
 ## Remaining Work (v1.0)
 


### PR DESCRIPTION
## Summary

Documentation/tracking-only change — no code.

- Adds a **"Xcode MCP bridge (preferred when connected)"** subsection under *Build & Development* in `CLAUDE.md`. It tells agents to prefer the `xcode` MCP tools (structured builds/tests/diagnostics from the open project) over scraping `xcodebuild` log text, lists the three preconditions (Intelligence toggle on, project open, session restarted), and documents the `xcodebuild` fallback plus the bridge's limits (doesn't manage Signing & Capabilities / provisioning).
- Adds issues **#47** (widget device verification), **#48** (no haptics on device), and **#49** (watchOS app) to the *Open GitHub Issues* list so they're tracked as scoped work.

## Test plan

No code changed; nothing to build or test. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)