### PR TITLE
Add watchOS quick-log companion app (#49)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,27 @@ xcodebuild -project Resistor.xcodeproj \
 **No CI/CD.** Local builds only.
 **Test target:** `ResistorTests` — unit tests for ViewModels, Models, and Services.
 
+**watchOS runtime required for the iOS test action.** The `Resistor` scheme now
+embeds the `ResistorWatch` watch app (Embed Watch Content phase), so
+`xcodebuild test -scheme Resistor …` builds the watch app and **fails on a fresh
+checkout without the watchOS simulator runtime** ("watchOS … must be installed in
+order to test the scheme"). Install it once with `xcodebuild -downloadPlatform
+watchOS` (~4 GB). Build the watch app directly with:
+
+```bash
+xcodebuild -project Resistor.xcodeproj \
+  -scheme ResistorWatch \
+  -destination 'generic/platform=watchOS Simulator' \
+  build
+```
+
+The watch app (`ResistorWatch/`) is a single-screen, tap-only quick-log
+companion (issue #49). It has its **own** SwiftData `ModelContainer` on the same
+CloudKit container (`iCloud.com.resistor.app`) — App Groups do **not** bridge
+iPhone↔Apple Watch, so phone/watch parity comes from CloudKit sync, not the
+shared App-Group store the widget uses. The target is wired by the idempotent
+`scripts/add_watch_target.rb` (rerun if the target is lost).
+
 ### Xcode MCP bridge (preferred when connected)
 
 An `xcode` MCP server (Apple's `xcrun mcpbridge`) is registered with Claude Code

--- a/Resistor.xcodeproj/project.pbxproj
+++ b/Resistor.xcodeproj/project.pbxproj
@@ -17,12 +17,19 @@
 		411562E8E9D44C6CAE3051F7 /* SelectHabitIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07168381249E78F8A95464E7 /* SelectHabitIntent.swift */; };
 		43CA41D12F89724100D11E7D /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CA41D02F89724100D11E7D /* LocationManager.swift */; };
 		43CA41D32F89730100D11E7D /* EventMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CA41D22F89730100D11E7D /* EventMapView.swift */; };
+		473FA6570E3A8419D4FE1399 /* TemptationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000C000000000000000A /* TemptationEvent.swift */; };
 		504578B580DC558233088F52 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D550B62AA43FA6F8E07A3859 /* Foundation.framework */; };
+		5577480B2A50DEAC74829F3E /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000E000000000000000A /* Color+Hex.swift */; };
 		5B9352C836AFB5E055E3C7D8 /* TemptationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000C000000000000000A /* TemptationEvent.swift */; };
 		5E290EEDAE694A24601B9B21 /* TemptationLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E671048A9259B7EBC8C1B43 /* TemptationLogger.swift */; };
+		62975B4D5E55D6B9286A334D /* WatchLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4597E26EF41C66F2BAD61A /* WatchLogView.swift */; };
 		6338F6467C5189388ECC395C /* ContextTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1000001000000000000000A /* ContextTag.swift */; };
+		6AD46C3EBEED5D591162E51E /* WatchLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D3AB0EA799474A518E40CE /* WatchLogStore.swift */; };
 		77053A802CD8451E81504253 /* HabitAppEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39097DA98DAC5F5C22FA4BD3 /* HabitAppEntity.swift */; };
+		8132D3C8C3A433BC0731783F /* ResistorWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32E0160D608ABC8D400DB5F /* ResistorWatchApp.swift */; };
 		8C41ECC1C5222C46E02AACD8 /* TemptationLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E671048A9259B7EBC8C1B43 /* TemptationLogger.swift */; };
+		9019D281C1C4357A3751544B /* ResistorWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 821F40704A2FEA56AED6D538 /* ResistorWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		9D3EDFD17E3756C5D1FCB5E7 /* WatchModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE4E3C730BCF819722BC72C /* WatchModelContainer.swift */; };
 		A1000001000000000000001A /* ResistorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000001000000000000000A /* ResistorApp.swift */; };
 		A1000002000000000000001A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000002000000000000000A /* ContentView.swift */; };
 		A1000003000000000000001A /* LogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000003000000000000000A /* LogView.swift */; };
@@ -54,19 +61,32 @@
 		B200000B000000000000001A /* InsightsViewModelPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000B000000000000000A /* InsightsViewModelPerformanceTests.swift */; };
 		B200000C000000000000001A /* TipJarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000C000000000000000A /* TipJarViewModelTests.swift */; };
 		B200000D000000000000001A /* DataExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000D000000000000000A /* DataExporterTests.swift */; };
-		B2000099000000000000001A /* TimeOfDayDrillDownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000099000000000000000A /* TimeOfDayDrillDownTests.swift */; };
 		B2000098000000000000001A /* QuickLogWidgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000098000000000000000A /* QuickLogWidgetTests.swift */; };
+		B200009A000000000000001A /* WatchLogStoreLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200009A000000000000000A /* WatchLogStoreLogicTests.swift */; };
+		B2000099000000000000001A /* TimeOfDayDrillDownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000099000000000000000A /* TimeOfDayDrillDownTests.swift */; };
 		B63040D04E809F970FF44C72 /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000E000000000000000A /* Color+Hex.swift */; };
+		BBE9A6248488296F235D2346 /* ContextTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1000001000000000000000A /* ContextTag.swift */; };
+		BD76B06DC4D4366E47940AA2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1880531AD4D2C420470F188 /* Foundation.framework */; };
 		C1000001000000000000001A /* ContextTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1000001000000000000000A /* ContextTag.swift */; };
+		C5AA35ACCC7EE25DC1CEB045 /* Habit.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000B000000000000000A /* Habit.swift */; };
 		CC9B3EE69FC6CED9DA5C375D /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34ABD48A949E05238016CBF /* SharedModelContainer.swift */; };
 		D354EB66006655563DFD61FB /* UITestSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A986130363EAECA937D1B7 /* UITestSeed.swift */; };
 		D4CBA1C324611D3CB789BE3E /* SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7A220FBBC346EEC2773BB4 /* SnapshotTests.swift */; };
 		DB24B141241DF326D4B0E457 /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34ABD48A949E05238016CBF /* SharedModelContainer.swift */; };
 		DDE9B5D235853D45E9B21BCD /* ResistorWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C931270813D632B915D37D59 /* ResistorWidgetBundle.swift */; };
+		E9EDE74E8B6B57BC689F9C14 /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000D000000000000000A /* UserSettings.swift */; };
+		EAEF7E8BCE46317330387F07 /* TemptationLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E671048A9259B7EBC8C1B43 /* TemptationLogger.swift */; };
 		EE9C4D3F81EBC93818857F9D /* Habit.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000B000000000000000A /* Habit.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		2F89A86D9FE69A633B05F7FB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A1000000000000000000005A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 76E2CC07855EBA50C692CD07;
+			remoteInfo = ResistorWatch;
+		};
 		7DB295D4016A1962AD804F76 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A1000000000000000000005A /* Project object */;
@@ -102,6 +122,17 @@
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B5A95AFB2123FDB1A8F861F4 /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				9019D281C1C4357A3751544B /* ResistorWatch.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -116,6 +147,11 @@
 		49F792C9FFECBD4172FA9C25 /* ResistorWidget.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = ResistorWidget.entitlements; sourceTree = "<group>"; };
 		656E85A95F778C45397ECA90 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6F4A323D24B5922D97906FD1 /* ResistorWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResistorWidget.swift; sourceTree = "<group>"; };
+		7D4597E26EF41C66F2BAD61A /* WatchLogView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchLogView.swift; sourceTree = "<group>"; };
+		80D3AB0EA799474A518E40CE /* WatchLogStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchLogStore.swift; sourceTree = "<group>"; };
+		8161180E40BC4690B0D6B00C /* ResistorWatch.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = ResistorWatch.entitlements; sourceTree = "<group>"; };
+		821F40704A2FEA56AED6D538 /* ResistorWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ResistorWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		8CE4E3C730BCF819722BC72C /* WatchModelContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchModelContainer.swift; sourceTree = "<group>"; };
 		912EC19ED1BF0A2FAA78B0EA /* ResistorUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ResistorUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A7A220FBBC346EEC2773BB4 /* SnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnapshotTests.swift; sourceTree = "<group>"; };
 		A1000000000000000000000A /* Resistor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Resistor.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -139,6 +175,7 @@
 		A1000013000000000000000A /* Resistor.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Resistor.entitlements; sourceTree = "<group>"; };
 		A1000014000000000000000A /* TipJar.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = TipJar.storekit; sourceTree = "<group>"; };
 		A1000015000000000000000A /* DataExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExporter.swift; sourceTree = "<group>"; };
+		B0F43B7161041B07A165E315 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B2000000000000000000000A /* ResistorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ResistorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2000001000000000000000A /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		B2000002000000000000000A /* InsightsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModelTests.swift; sourceTree = "<group>"; };
@@ -153,15 +190,18 @@
 		B200000B000000000000000A /* InsightsViewModelPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModelPerformanceTests.swift; sourceTree = "<group>"; };
 		B200000C000000000000000A /* TipJarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipJarViewModelTests.swift; sourceTree = "<group>"; };
 		B200000D000000000000000A /* DataExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExporterTests.swift; sourceTree = "<group>"; };
-		B2000099000000000000000A /* TimeOfDayDrillDownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeOfDayDrillDownTests.swift; sourceTree = "<group>"; };
 		B2000098000000000000000A /* QuickLogWidgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLogWidgetTests.swift; sourceTree = "<group>"; };
+		B200009A000000000000000A /* WatchLogStoreLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchLogStoreLogicTests.swift; sourceTree = "<group>"; };
+		B2000099000000000000000A /* TimeOfDayDrillDownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeOfDayDrillDownTests.swift; sourceTree = "<group>"; };
 		C1000001000000000000000A /* ContextTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextTag.swift; sourceTree = "<group>"; };
+		C1880531AD4D2C420470F188 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS11.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		C931270813D632B915D37D59 /* ResistorWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResistorWidgetBundle.swift; sourceTree = "<group>"; };
 		D34ABD48A949E05238016CBF /* SharedModelContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharedModelContainer.swift; sourceTree = "<group>"; };
 		D550B62AA43FA6F8E07A3859 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		DCA4656BDF208C2526724BEB /* LogResistedIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogResistedIntent.swift; sourceTree = "<group>"; };
 		DF18F3D313F229C82C59743E /* ResistorWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ResistorWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7A986130363EAECA937D1B7 /* UITestSeed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UITestSeed.swift; sourceTree = "<group>"; };
+		F32E0160D608ABC8D400DB5F /* ResistorWatchApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResistorWatchApp.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -195,9 +235,39 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EC690A6CFBF7AE0C2D0F24E8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BD76B06DC4D4366E47940AA2 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		011F37B0423D8FB4DB63CDC5 /* ResistorWatch */ = {
+			isa = PBXGroup;
+			children = (
+				F32E0160D608ABC8D400DB5F /* ResistorWatchApp.swift */,
+				80D3AB0EA799474A518E40CE /* WatchLogStore.swift */,
+				7D4597E26EF41C66F2BAD61A /* WatchLogView.swift */,
+				8CE4E3C730BCF819722BC72C /* WatchModelContainer.swift */,
+				B0F43B7161041B07A165E315 /* Info.plist */,
+				8161180E40BC4690B0D6B00C /* ResistorWatch.entitlements */,
+			);
+			name = ResistorWatch;
+			path = ResistorWatch;
+			sourceTree = "<group>";
+		};
+		0833E1EBA7B1C7AEC64AB2F1 /* watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				C1880531AD4D2C420470F188 /* Foundation.framework */,
+			);
+			name = watchOS;
+			sourceTree = "<group>";
+		};
 		34EE3083C015C6E3C9BB1CD1 /* ResistorUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -238,6 +308,7 @@
 			isa = PBXGroup;
 			children = (
 				CE705E2CBA64036A22E00A5A /* iOS */,
+				0833E1EBA7B1C7AEC64AB2F1 /* watchOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -251,6 +322,7 @@
 				969C8B9E7218FDE17632ABE0 /* Frameworks */,
 				34EE3083C015C6E3C9BB1CD1 /* ResistorUITests */,
 				38FAD11F73233976C5E40B7B /* ResistorWidget */,
+				011F37B0423D8FB4DB63CDC5 /* ResistorWatch */,
 			);
 			sourceTree = "<group>";
 		};
@@ -279,6 +351,7 @@
 				B2000000000000000000000A /* ResistorTests.xctest */,
 				912EC19ED1BF0A2FAA78B0EA /* ResistorUITests.xctest */,
 				DF18F3D313F229C82C59743E /* ResistorWidget.appex */,
+				821F40704A2FEA56AED6D538 /* ResistorWatch.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -345,6 +418,7 @@
 				B2000002000000000000000A /* InsightsViewModelTests.swift */,
 				B2000099000000000000000A /* TimeOfDayDrillDownTests.swift */,
 				B2000098000000000000000A /* QuickLogWidgetTests.swift */,
+				B200009A000000000000000A /* WatchLogStoreLogicTests.swift */,
 				B2000003000000000000000A /* TemptationEventTests.swift */,
 				B2000004000000000000000A /* HabitsViewModelTests.swift */,
 				B2000005000000000000000A /* LogViewModelTests.swift */,
@@ -388,6 +462,23 @@
 			productReference = DF18F3D313F229C82C59743E /* ResistorWidget.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		76E2CC07855EBA50C692CD07 /* ResistorWatch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 59ADAD1C28CD641C4A87CE62 /* Build configuration list for PBXNativeTarget "ResistorWatch" */;
+			buildPhases = (
+				C64D20DB94A71551E1001DF7 /* Sources */,
+				EC690A6CFBF7AE0C2D0F24E8 /* Frameworks */,
+				86402CBD0E4435CE47DCD22A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ResistorWatch;
+			productName = ResistorWatch;
+			productReference = 821F40704A2FEA56AED6D538 /* ResistorWatch.app */;
+			productType = "com.apple.product-type.application";
+		};
 		A1000000000000000000004A /* Resistor */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A1000002000000000000005A /* Build configuration list for PBXNativeTarget "Resistor" */;
@@ -396,11 +487,13 @@
 				A1000000000000000000002A /* Frameworks */,
 				A1000002000000000000004A /* Resources */,
 				521C92D8AE7DE0DF6402FFCC /* Embed Foundation Extensions */,
+				B5A95AFB2123FDB1A8F861F4 /* Embed Watch Content */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				30CBD047345AEEC1A47413D4 /* PBXTargetDependency */,
+				D186095CB259AD43E77B8D73 /* PBXTargetDependency */,
 			);
 			name = Resistor;
 			productName = Resistor;
@@ -478,11 +571,19 @@
 				B2000000000000000000004A /* ResistorTests */,
 				B9F79058ED76416224DE5D15 /* ResistorUITests */,
 				23E13FD62591E63A1BC9D959 /* ResistorWidget */,
+				76E2CC07855EBA50C692CD07 /* ResistorWatch */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		86402CBD0E4435CE47DCD22A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A1000002000000000000004A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -575,6 +676,7 @@
 				B2000002000000000000001A /* InsightsViewModelTests.swift in Sources */,
 				B2000099000000000000001A /* TimeOfDayDrillDownTests.swift in Sources */,
 				B2000098000000000000001A /* QuickLogWidgetTests.swift in Sources */,
+				B200009A000000000000001A /* WatchLogStoreLogicTests.swift in Sources */,
 				B2000003000000000000001A /* TemptationEventTests.swift in Sources */,
 				B2000004000000000000001A /* HabitsViewModelTests.swift in Sources */,
 				B2000005000000000000001A /* LogViewModelTests.swift in Sources */,
@@ -586,6 +688,23 @@
 				B200000B000000000000001A /* InsightsViewModelPerformanceTests.swift in Sources */,
 				B200000C000000000000001A /* TipJarViewModelTests.swift in Sources */,
 				B200000D000000000000001A /* DataExporterTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C64D20DB94A71551E1001DF7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8132D3C8C3A433BC0731783F /* ResistorWatchApp.swift in Sources */,
+				6AD46C3EBEED5D591162E51E /* WatchLogStore.swift in Sources */,
+				62975B4D5E55D6B9286A334D /* WatchLogView.swift in Sources */,
+				9D3EDFD17E3756C5D1FCB5E7 /* WatchModelContainer.swift in Sources */,
+				C5AA35ACCC7EE25DC1CEB045 /* Habit.swift in Sources */,
+				473FA6570E3A8419D4FE1399 /* TemptationEvent.swift in Sources */,
+				E9EDE74E8B6B57BC689F9C14 /* UserSettings.swift in Sources */,
+				BBE9A6248488296F235D2346 /* ContextTag.swift in Sources */,
+				5577480B2A50DEAC74829F3E /* Color+Hex.swift in Sources */,
+				EAEF7E8BCE46317330387F07 /* TemptationLogger.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -608,6 +727,12 @@
 			isa = PBXTargetDependency;
 			target = A1000000000000000000004A /* Resistor */;
 			targetProxy = B2000001000000000000007A /* PBXContainerItemProxy */;
+		};
+		D186095CB259AD43E77B8D73 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ResistorWatch;
+			target = 76E2CC07855EBA50C692CD07 /* ResistorWatch */;
+			targetProxy = 2F89A86D9FE69A633B05F7FB /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -646,6 +771,41 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = Resistor;
+			};
+			name = Debug;
+		};
+		3FA008DE69D5C7186ACE7D71 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ResistorWatch/ResistorWatch.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = HBXLU45HR7;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ResistorWatch/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Resistor;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKApplication = YES;
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.resistor.app;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.resistor.app.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "watchos watchsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
 		};
@@ -943,9 +1103,54 @@
 			};
 			name = Release;
 		};
+		BE6BD1A602F74A1CB179236A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ResistorWatch/ResistorWatch.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = HBXLU45HR7;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ResistorWatch/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Resistor;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKApplication = YES;
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.resistor.app;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.resistor.app.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "watchos watchsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		59ADAD1C28CD641C4A87CE62 /* Build configuration list for PBXNativeTarget "ResistorWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BE6BD1A602F74A1CB179236A /* Release */,
+				3FA008DE69D5C7186ACE7D71 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		8E2093EE44BA43A6B52F3E88 /* Build configuration list for PBXNativeTarget "ResistorUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Resistor.xcodeproj/xcshareddata/xcschemes/ResistorWatch.xcscheme
+++ b/Resistor.xcodeproj/xcshareddata/xcschemes/ResistorWatch.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "76E2CC07855EBA50C692CD07"
+               BuildableName = "ResistorWatch.app"
+               BlueprintName = "ResistorWatch"
+               ReferencedContainer = "container:Resistor.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "76E2CC07855EBA50C692CD07"
+            BuildableName = "ResistorWatch.app"
+            BlueprintName = "ResistorWatch"
+            ReferencedContainer = "container:Resistor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "76E2CC07855EBA50C692CD07"
+            BuildableName = "ResistorWatch.app"
+            BlueprintName = "ResistorWatch"
+            ReferencedContainer = "container:Resistor.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "76E2CC07855EBA50C692CD07"
+            BuildableName = "ResistorWatch.app"
+            BlueprintName = "ResistorWatch"
+            ReferencedContainer = "container:Resistor.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ResistorTests/WatchLogStoreLogicTests.swift
+++ b/ResistorTests/WatchLogStoreLogicTests.swift
@@ -1,0 +1,313 @@
+import XCTest
+import SwiftData
+@testable import Resistor
+
+/// Unit tests for the watchOS Quick-Log companion's *pure logic* (issue #49,
+/// UC-WATCH-1…7), exercised against the shared SwiftData models.
+///
+/// `WatchLogStore` itself is compiled only into the `ResistorWatch` (watchOS)
+/// target and therefore CANNOT be imported into this iOS test target — there is
+/// no watch test target on this checkout, and standing one up is out of scope.
+/// So, exactly as `QuickLogWidgetTests` does for the widget extension, these
+/// tests re-verify the *same* resolution and counting logic the watch store
+/// implements (`WatchLogStore.resolveTargetHabit`, `.activeHabits`,
+/// `.todayResistedCount`) against an in-memory store. The algorithm is
+/// duplicated here verbatim from the watch source; if the watch logic changes,
+/// these must change with it.
+///
+/// NOT covered here (watch-target-only, manual on hardware): the 800ms debounce
+/// in `WatchLogView.handleTap`, the `.success` Taptic haptic, the CloudKit
+/// cross-device sync, and the `WatchModelContainer` CloudKit container open.
+@MainActor
+final class WatchLogStoreLogicTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestHelpers.makeModelContainer()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        container = nil
+        context = nil
+    }
+
+    // MARK: - Mirror of WatchLogStore's private logic
+
+    /// Verbatim copy of `WatchLogStore.activeHabits(in:)`.
+    private func activeHabits() -> [Habit] {
+        let descriptor = FetchDescriptor<Habit>(
+            predicate: #Predicate { !$0.isArchived },
+            sortBy: [
+                SortDescriptor(\Habit.createdAt, order: .forward),
+                SortDescriptor(\Habit.id, order: .forward)
+            ]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    private func defaultHabitId() -> UUID? {
+        let descriptor = FetchDescriptor<UserSettings>()
+        return (try? context.fetch(descriptor))?.first?.defaultHabitId
+    }
+
+    /// Verbatim copy of `WatchLogStore.resolveTargetHabit(in:)`.
+    private func resolveTargetHabit() -> Habit? {
+        let active = activeHabits()
+        guard !active.isEmpty else { return nil }
+        if let defaultID = defaultHabitId(),
+           let match = active.first(where: { $0.id == defaultID }) {
+            return match
+        }
+        return active.first
+    }
+
+    /// Verbatim copy of `WatchLogStore.hasConfiguredButMissingDefault(in:)`.
+    private func hasConfiguredButMissingDefault() -> Bool {
+        guard let defaultID = defaultHabitId() else { return false }
+        return !activeHabits().contains { $0.id == defaultID }
+    }
+
+    /// Verbatim copy of `WatchLogStore.todayResistedCount(for:in:)`.
+    private func todayResistedCount(for habit: Habit) -> Int {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        return habit.safeEvents.filter { event in
+            event.outcomeEnum == .resisted &&
+            calendar.isDate(event.occurredAt, inSameDayAs: today)
+        }.count
+    }
+
+    private func makeSettings(defaultHabitId: UUID?) -> UserSettings {
+        let s = UserSettings()
+        s.defaultHabitId = defaultHabitId
+        return s
+    }
+
+    // MARK: - UC-WATCH-7: target resolution (default → deterministic first)
+
+    /// With a valid configured default that points at a live non-archived habit,
+    /// that habit is the target even when it isn't first in createdAt order.
+    func testResolvePrefersConfiguredDefault() throws {
+        let first = TestHelpers.makeHabit(name: "First", createdAt: Date(timeIntervalSince1970: 100))
+        let second = TestHelpers.makeHabit(name: "Second", createdAt: Date(timeIntervalSince1970: 200))
+        context.insert(first)
+        context.insert(second)
+        context.insert(makeSettings(defaultHabitId: second.id))
+        try context.save()
+
+        let target = try XCTUnwrap(resolveTargetHabit())
+        XCTAssertEqual(target.id, second.id, "configured default wins over createdAt order")
+    }
+
+    /// With no default configured, resolution falls back to the deterministic
+    /// first non-archived habit (earliest createdAt).
+    func testResolveFallsBackToFirstNonArchivedByCreatedAt() throws {
+        let later = TestHelpers.makeHabit(name: "Later", createdAt: Date(timeIntervalSince1970: 300))
+        let earlier = TestHelpers.makeHabit(name: "Earlier", createdAt: Date(timeIntervalSince1970: 100))
+        context.insert(later)
+        context.insert(earlier)
+        // No UserSettings at all.
+        try context.save()
+
+        let target = try XCTUnwrap(resolveTargetHabit())
+        XCTAssertEqual(target.id, earlier.id, "earliest createdAt is the deterministic fallback")
+    }
+
+    /// Resolution is stable/deterministic across repeated reads (no random order).
+    func testResolutionIsDeterministicAcrossReads() throws {
+        for i in 0..<5 {
+            context.insert(TestHelpers.makeHabit(name: "H\(i)", createdAt: Date(timeIntervalSince1970: 100)))
+        }
+        try context.save()
+
+        let firstResolve = try XCTUnwrap(resolveTargetHabit()).id
+        for _ in 0..<10 {
+            XCTAssertEqual(try XCTUnwrap(resolveTargetHabit()).id, firstResolve,
+                           "same target every read even with equal createdAt (tiebreak by id)")
+        }
+    }
+
+    /// An archived default is NOT the target; resolution falls back to the first
+    /// live non-archived habit instead (never logs to an archived habit).
+    func testArchivedDefaultFallsBackToLiveHabit() throws {
+        let archivedDefault = TestHelpers.makeHabit(name: "Archived", isArchived: true, createdAt: Date(timeIntervalSince1970: 100))
+        let live = TestHelpers.makeHabit(name: "Live", createdAt: Date(timeIntervalSince1970: 200))
+        context.insert(archivedDefault)
+        context.insert(live)
+        context.insert(makeSettings(defaultHabitId: archivedDefault.id))
+        try context.save()
+
+        let target = try XCTUnwrap(resolveTargetHabit())
+        XCTAssertEqual(target.id, live.id, "archived default is skipped; live habit is target")
+        XCTAssertFalse(target.isArchived)
+    }
+
+    /// The resolved target always has a usable name (UC-WATCH-7: never logs to an
+    /// unnamed target). Here every active habit is named, so resolution yields a
+    /// named habit; a habit with empty name would not be created by the app flow.
+    func testResolvedTargetIsNamed() throws {
+        let h = TestHelpers.makeHabit(name: "Named Habit", createdAt: Date(timeIntervalSince1970: 100))
+        context.insert(h)
+        try context.save()
+
+        let target = try XCTUnwrap(resolveTargetHabit())
+        XCTAssertFalse(target.name.isEmpty, "target habit must be named")
+    }
+
+    // MARK: - UC-WATCH-5: non-loggable states resolve, never a false target
+
+    /// No habits at all → no target resolves → state (d) noHabit (the View shows
+    /// the non-loggable branch and a tap cannot log).
+    func testNoHabitsResolvesToNoTarget() throws {
+        // Empty store.
+        XCTAssertNil(resolveTargetHabit(), "no habits → no resolvable target")
+        XCTAssertFalse(hasConfiguredButMissingDefault(), "no default configured → state (d), not (e)")
+    }
+
+    /// All habits archived → no target resolves (UC-WATCH-5: habit unavailable,
+    /// tap can't log).
+    func testAllArchivedResolvesToNoTarget() throws {
+        context.insert(TestHelpers.makeHabit(name: "A", isArchived: true))
+        context.insert(TestHelpers.makeHabit(name: "B", isArchived: true))
+        try context.save()
+
+        XCTAssertNil(resolveTargetHabit(), "all archived → no resolvable target")
+    }
+
+    /// A configured default that is now gone with NO fallback distinguishes state
+    /// (e) habitUnavailable from (d) noHabit.
+    func testConfiguredDefaultMissingWithNoFallbackIsHabitUnavailable() throws {
+        let goneID = UUID() // never inserted
+        context.insert(makeSettings(defaultHabitId: goneID))
+        try context.save()
+
+        XCTAssertNil(resolveTargetHabit(), "default points nowhere and no other habit exists")
+        XCTAssertTrue(hasConfiguredButMissingDefault(),
+                      "configured-but-missing default → state (e) habitUnavailable, not (d)")
+    }
+
+    /// A configured default that was archived, with another live habit present,
+    /// resolves to the live habit (does NOT become habitUnavailable) — matches the
+    /// watch's resolve-then-fallback ordering.
+    func testArchivedDefaultWithFallbackIsLoggableNotUnavailable() throws {
+        let archived = TestHelpers.makeHabit(name: "Archived", isArchived: true, createdAt: Date(timeIntervalSince1970: 100))
+        let live = TestHelpers.makeHabit(name: "Live", createdAt: Date(timeIntervalSince1970: 200))
+        context.insert(archived)
+        context.insert(live)
+        context.insert(makeSettings(defaultHabitId: archived.id))
+        try context.save()
+
+        XCTAssertNotNil(resolveTargetHabit(), "a live fallback exists → loggable, not unavailable")
+        XCTAssertEqual(resolveTargetHabit()?.id, live.id)
+    }
+
+    // MARK: - UC-WATCH-3: today's resisted count (calendar-day, resisted-only)
+
+    /// Counts only resisted events in the current calendar day (mirrors
+    /// `Habit.todayEventsCount`'s day rule, filtered to resisted).
+    func testTodayResistedCountResistedOnlyToday() throws {
+        let habit = TestHelpers.makeHabit(name: "Counted")
+        context.insert(habit)
+        try context.save()
+
+        // Two resisted today.
+        TemptationLogger.logResisted(for: habit, in: context)
+        TemptationLogger.logResisted(for: habit, in: context)
+        // A gave_in today — must NOT count (resisted-only).
+        context.insert(TestHelpers.makeEvent(habit: habit, outcome: "gave_in"))
+        // An unknown today — must NOT count.
+        context.insert(TestHelpers.makeEvent(habit: habit, outcome: "unknown"))
+        // A resisted yesterday — must NOT count (today-only).
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        context.insert(TestHelpers.makeEvent(habit: habit, occurredAt: yesterday, outcome: "resisted"))
+        try context.save()
+
+        XCTAssertEqual(todayResistedCount(for: habit), 2,
+                       "only today's resisted events count")
+    }
+
+    /// The watch's resisted-today count never exceeds (and tracks a subset of)
+    /// `Habit.todayEventsCount`: same day rule, resisted is a subset of all
+    /// outcomes.
+    func testResistedTodayIsSubsetOfTodayEventsCount() throws {
+        let habit = TestHelpers.makeHabit(name: "Subset")
+        context.insert(habit)
+        try context.save()
+
+        TemptationLogger.logResisted(for: habit, in: context)              // resisted
+        context.insert(TestHelpers.makeEvent(habit: habit, outcome: "gave_in")) // not resisted
+        try context.save()
+
+        XCTAssertEqual(habit.todayEventsCount, 2, "all-outcome today count")
+        XCTAssertEqual(todayResistedCount(for: habit), 1, "resisted-only today count")
+        XCTAssertLessThanOrEqual(todayResistedCount(for: habit), habit.todayEventsCount)
+    }
+
+    /// Count is per-target-habit: another habit's resisted events don't leak in.
+    func testResistedTodayIsPerHabit() throws {
+        let a = TestHelpers.makeHabit(name: "A")
+        let b = TestHelpers.makeHabit(name: "B")
+        context.insert(a)
+        context.insert(b)
+        try context.save()
+
+        TemptationLogger.logResisted(for: a, in: context)
+        TemptationLogger.logResisted(for: b, in: context)
+        TemptationLogger.logResisted(for: b, in: context)
+
+        XCTAssertEqual(todayResistedCount(for: a), 1)
+        XCTAssertEqual(todayResistedCount(for: b), 2)
+    }
+
+    /// A freshly-resolved target with no events reads 0 (a true 0, not the
+    /// count-unavailable nil branch which only the watch's store-open failure
+    /// produces).
+    func testResistedTodayZeroForFreshHabit() throws {
+        let habit = TestHelpers.makeHabit(name: "Fresh")
+        context.insert(habit)
+        try context.save()
+        XCTAssertEqual(todayResistedCount(for: habit), 0)
+    }
+
+    // MARK: - UC-WATCH-1 / -6: one tap = one event; two taps = two events
+
+    /// One log against the resolved target writes exactly one resisted event with
+    /// the watch's event shape (intensity nil, no tags), via the shared logger.
+    func testLogResolvedTargetWritesExactlyOneResistedEvent() throws {
+        let habit = TestHelpers.makeHabit(name: "Tap")
+        context.insert(habit)
+        try context.save()
+
+        let target = try XCTUnwrap(resolveTargetHabit())
+        let event = try XCTUnwrap(TemptationLogger.logResisted(for: target, in: context))
+
+        XCTAssertEqual(event.outcomeEnum, .resisted)
+        XCTAssertNil(event.intensity, "watch log: intensity nil (user did not engage scale)")
+        XCTAssertEqual(event.contextTags, [], "watch log: no context tags")
+        XCTAssertEqual(event.habit?.id, habit.id)
+
+        let all = try context.fetch(FetchDescriptor<TemptationEvent>())
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(todayResistedCount(for: habit), 1, "count reflects the new event")
+    }
+
+    /// Two deliberate logs = two distinct events (the 800ms debounce that
+    /// collapses an accidental double-contact lives in the View, not in this data
+    /// path; two real taps must both write).
+    func testTwoDeliberateLogsWriteTwoEvents() throws {
+        let habit = TestHelpers.makeHabit(name: "TwoTaps")
+        context.insert(habit)
+        try context.save()
+
+        let target = try XCTUnwrap(resolveTargetHabit())
+        let first = try XCTUnwrap(TemptationLogger.logResisted(for: target, in: context))
+        let second = try XCTUnwrap(TemptationLogger.logResisted(for: target, in: context))
+
+        XCTAssertNotEqual(first.id, second.id, "two distinct events")
+        XCTAssertEqual(try context.fetch(FetchDescriptor<TemptationEvent>()).count, 2)
+        XCTAssertEqual(todayResistedCount(for: habit), 2)
+    }
+}

--- a/ResistorWatch/Info.plist
+++ b/ResistorWatch/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>WKApplication</key>
+	<true/>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>com.resistor.app</string>
+</dict>
+</plist>

--- a/ResistorWatch/ResistorWatch.entitlements
+++ b/ResistorWatch/ResistorWatch.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.resistor.app</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+</dict>
+</plist>

--- a/ResistorWatch/ResistorWatchApp.swift
+++ b/ResistorWatch/ResistorWatchApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+/// watchOS Quick-Log companion app entry point. A single-window, single-screen
+/// app: one tap logs a resisted temptation against the resolved target habit and
+/// CloudKit syncs it to the phone.
+@main
+struct ResistorWatchApp: App {
+    var body: some Scene {
+        WindowGroup {
+            WatchLogView()
+        }
+    }
+}

--- a/ResistorWatch/WatchLogStore.swift
+++ b/ResistorWatch/WatchLogStore.swift
@@ -1,0 +1,159 @@
+import Foundation
+import SwiftData
+import Observation
+
+/// The resolved render state for the watch Quick-Log screen. Mirrors the UX
+/// spec's states (a)/(d)/(e)/(f) — a loggable target with a known count, a
+/// loggable target whose count read failed, no habit at all, or a configured
+/// default that is no longer valid with no fallback.
+enum WatchLogState: Equatable {
+    /// (a)/(f) Loggable. A valid target habit is resolved and named. `count` is
+    /// `nil` when the count read failed (render "Count unavailable", never a
+    /// false 0); the button stays loggable either way.
+    case loggable(habitID: UUID, name: String, colorHex: String?, iconName: String?, count: Int?)
+    /// (d) No habit exists to log against.
+    case noHabit
+    /// (e) A default was set but is now archived/deleted and no other
+    /// non-archived habit exists to fall back to.
+    case habitUnavailable
+}
+
+/// The single data path for the watch Quick-Log screen. Owns the watch-side
+/// `ModelContext`, resolves the target habit (default → else sole/first
+/// non-archived habit, deterministic order), reads today's resisted count, and
+/// performs the log via the shared `TemptationLogger`.
+///
+/// Kept as a small reusable provider (not inlined in the View) so a future
+/// complication is just a new presentation over the same `state` /
+/// `todayResistedCount(for:)` data path.
+@Observable
+final class WatchLogStore {
+
+    /// The current render state. The View observes this.
+    private(set) var state: WatchLogState = .noHabit
+
+    /// `nil` when the watch store could not be opened (CloudKit/container
+    /// failure). The View renders the count-unavailable branch when a target is
+    /// otherwise known.
+    private let modelContext: ModelContext?
+
+    init() {
+        if let container = try? WatchModelContainer.makeContainer() {
+            self.modelContext = ModelContext(container)
+        } else {
+            self.modelContext = nil
+        }
+        refresh()
+    }
+
+    /// Recomputes `state` from the store: resolves the target habit and reads
+    /// today's count.
+    func refresh() {
+        guard let context = modelContext else {
+            // Store unavailable entirely — we can't even resolve a habit. Treat
+            // as no-habit rather than inventing a target.
+            state = .noHabit
+            return
+        }
+
+        guard let habit = resolveTargetHabit(in: context) else {
+            // Distinguish (e) from (d): if a default was configured but is gone
+            // and there's truly nothing to fall back to, it's "habit
+            // unavailable"; otherwise there simply is no habit yet.
+            if hasConfiguredButMissingDefault(in: context) {
+                state = .habitUnavailable
+            } else {
+                state = .noHabit
+            }
+            return
+        }
+
+        let count = todayResistedCount(for: habit, in: context)
+        state = .loggable(
+            habitID: habit.id,
+            name: habit.name,
+            colorHex: habit.colorHex,
+            iconName: habit.iconName,
+            count: count
+        )
+    }
+
+    /// Logs one resisted temptation against the currently-resolved target habit,
+    /// then refreshes the count. Returns `true` on a successful save.
+    ///
+    /// Writes to the local watch store immediately; CloudKit syncs to the phone
+    /// whenever it can. Does NOT depend on WatchConnectivity reachability.
+    @discardableResult
+    func logResisted() -> Bool {
+        guard let context = modelContext,
+              case let .loggable(habitID, _, _, _, _) = state else {
+            return false
+        }
+        let descriptor = FetchDescriptor<Habit>(
+            predicate: #Predicate { $0.id == habitID }
+        )
+        guard let habit = try? context.fetch(descriptor).first else {
+            return false
+        }
+        let event = TemptationLogger.logResisted(for: habit, in: context)
+        refresh()
+        return event != nil
+    }
+
+    // MARK: - Target resolution
+
+    /// Resolves the target habit: `UserSettings.defaultHabitId` if it points at a
+    /// live non-archived habit, else the sole/first non-archived habit in a
+    /// deterministic order (by `createdAt`, then `id`). Returns `nil` only when
+    /// no non-archived habit exists at all.
+    private func resolveTargetHabit(in context: ModelContext) -> Habit? {
+        let active = activeHabits(in: context)
+        guard !active.isEmpty else { return nil }
+
+        if let defaultID = defaultHabitId(in: context),
+           let match = active.first(where: { $0.id == defaultID }) {
+            return match
+        }
+        // Deterministic fallback so the watch always names a stable target.
+        return active.first
+    }
+
+    /// All non-archived habits in a deterministic order.
+    private func activeHabits(in context: ModelContext) -> [Habit] {
+        let descriptor = FetchDescriptor<Habit>(
+            predicate: #Predicate { !$0.isArchived },
+            sortBy: [
+                SortDescriptor(\Habit.createdAt, order: .forward),
+                SortDescriptor(\Habit.id, order: .forward)
+            ]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    private func defaultHabitId(in context: ModelContext) -> UUID? {
+        let descriptor = FetchDescriptor<UserSettings>()
+        return (try? context.fetch(descriptor))?.first?.defaultHabitId
+    }
+
+    /// True when a default habit id was configured but no longer resolves to a
+    /// live non-archived habit. Used to choose state (e) over (d).
+    private func hasConfiguredButMissingDefault(in context: ModelContext) -> Bool {
+        guard let defaultID = defaultHabitId(in: context) else { return false }
+        return !activeHabits(in: context).contains { $0.id == defaultID }
+    }
+
+    // MARK: - Count
+
+    /// Today's *resisted* event count for `habit`, using the same calendar-day
+    /// definition as `Habit.todayEventsCount` (events in the current calendar
+    /// day) but filtered to the resisted outcome only.
+    func todayResistedCount(for habit: Habit, in context: ModelContext) -> Int? {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        // Habit.safeEvents is the same source the phone counts from.
+        return habit.safeEvents.filter { event in
+            event.outcomeEnum == .resisted &&
+            calendar.isDate(event.occurredAt, inSameDayAs: today)
+        }.count
+    }
+}

--- a/ResistorWatch/WatchLogView.swift
+++ b/ResistorWatch/WatchLogView.swift
@@ -1,0 +1,229 @@
+import SwiftUI
+import WatchKit
+
+/// The watch Quick-Log screen. ONE screen, no NavigationStack/tabs/Crown.
+/// Tap-only: one tap → one resisted `TemptationEvent`. The phone's 3s hold ramp
+/// is deliberately dropped on the watch.
+struct WatchLogView: View {
+    @State private var vm: WatchLogStore?
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Debounce window: the button is disabled briefly after a tap so a
+    /// double-contact yields exactly one event.
+    private static let debounce: TimeInterval = 0.8
+    /// How long the "Logged" acknowledgement dwells before auto-dismissing.
+    private static let ackDwell: TimeInterval = 1.2
+
+    @State private var isLogging = false
+    @State private var showAck = false
+
+    var body: some View {
+        ScrollView {
+            content
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 4)
+        }
+        .onAppear {
+            if vm == nil {
+                vm = WatchLogStore()
+            } else {
+                vm?.refresh()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let vm {
+            switch vm.state {
+            case let .loggable(_, name, colorHex, iconName, count):
+                loggable(name: name, colorHex: colorHex, iconName: iconName, count: count)
+            case .noHabit:
+                nonLoggable(
+                    symbol: "square.dashed",
+                    title: "No habit to log",
+                    subtitle: "Add a habit on your phone"
+                )
+            case .habitUnavailable:
+                nonLoggable(
+                    symbol: "exclamationmark.triangle",
+                    title: "Habit unavailable",
+                    subtitle: "Set a default habit on your phone"
+                )
+            }
+        } else {
+            // Pre-init frame; render nothing rather than a flash of wrong state.
+            Color.clear.frame(height: 1)
+        }
+    }
+
+    // MARK: - (a)/(b)/(c)/(f) Loggable
+
+    @ViewBuilder
+    private func loggable(name: String, colorHex: String?, iconName: String?, count: Int?) -> some View {
+        let habitColor = Color(hex: colorHex ?? "#007AFF") ?? .blue
+        let symbol = iconName ?? "circle.fill"
+
+        VStack(spacing: 8) {
+            Text(name)
+                .font(.headline)
+                .fontWeight(.semibold)
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .minimumScaleFactor(0.8)
+
+            ZStack {
+                Button(action: handleTap) {
+                    Circle()
+                        .fill(isLogging ? habitColor.opacity(0.5) : habitColor)
+                        .overlay(
+                            Image(systemName: symbol)
+                                .font(.system(size: 36, weight: .semibold))
+                                .foregroundStyle(.white)
+                        )
+                        .aspectRatio(1, contentMode: .fit)
+                }
+                .buttonStyle(.plain)
+                .disabled(isLogging)
+
+                acknowledgement
+            }
+            .frame(maxWidth: .infinity)
+            .frame(width: buttonContainerWidth)
+            .accessibilityElement(children: .ignore)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel(buttonAccessibilityLabel(name: name, count: count))
+            .accessibilityHint("Logs a resisted temptation.")
+            .accessibilityAction { handleTap() }
+
+            countLine(count: count)
+        }
+        .padding(.horizontal, 4)
+    }
+
+    /// Caps the button width to ~60–66% of the screen so the circle stays the
+    /// designed proportion regardless of watch size.
+    private var buttonContainerWidth: CGFloat {
+        WKInterfaceDevice.current().screenBounds.width * 0.63
+    }
+
+    @ViewBuilder
+    private var acknowledgement: some View {
+        if showAck {
+            VStack(spacing: 2) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(.green)
+                Text("Logged")
+                    .font(.headline)
+                    .fontWeight(.semibold)
+            }
+            .padding(8)
+            .background(.black.opacity(0.55), in: RoundedRectangle(cornerRadius: 12))
+            .transition(reduceMotion ? .identity : .scale(scale: 0.9).combined(with: .opacity))
+        }
+    }
+
+    @ViewBuilder
+    private func countLine(count: Int?) -> some View {
+        Group {
+            if let count {
+                ViewThatFits {
+                    Text("Today: \(count) logged")
+                    Text("\(count) today")
+                }
+            } else {
+                Text("Count unavailable")
+            }
+        }
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+        .accessibilityHidden(true) // folded into the button label
+    }
+
+    private func buttonAccessibilityLabel(name: String, count: Int?) -> String {
+        if let count {
+            return "\(name), \(count) logged today"
+        }
+        return "\(name), count unavailable"
+    }
+
+    // MARK: - (d)/(e) Non-loggable
+
+    @ViewBuilder
+    private func nonLoggable(symbol: String, title: String, subtitle: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: symbol)
+                .font(.system(size: 36))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+            Text(subtitle)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title). \(subtitle).")
+    }
+
+    // MARK: - Interaction
+
+    private func handleTap() {
+        guard let vm, !isLogging else { return }
+
+        // (b) in-flight: disable + dim immediately. Snap when Reduce Motion.
+        if reduceMotion {
+            isLogging = true
+        } else {
+            withAnimation(.easeInOut(duration: 0.12)) { isLogging = true }
+        }
+
+        let success = vm.logResisted()
+
+        guard success else {
+            // Re-enable; no error/shake per spec.
+            reEnableAfterDebounce()
+            return
+        }
+
+        // Haptic on successful log only.
+        WKInterfaceDevice.current().play(.success)
+
+        // (c) success ack: a display layer over a still-live button.
+        if reduceMotion {
+            showAck = true
+        } else {
+            withAnimation(.easeOut(duration: 0.15)) { showAck = true }
+        }
+
+        // Re-enable the button after the debounce so a real second urge can
+        // re-tap and restart the ack while it is still showing.
+        reEnableAfterDebounce()
+
+        // Auto-dismiss the ack after its dwell.
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.ackDwell) {
+            if reduceMotion {
+                showAck = false
+            } else {
+                withAnimation(.easeIn(duration: 0.2)) { showAck = false }
+            }
+        }
+    }
+
+    private func reEnableAfterDebounce() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.debounce) {
+            if reduceMotion {
+                isLogging = false
+            } else {
+                withAnimation(.easeInOut(duration: 0.12)) { isLogging = false }
+            }
+        }
+    }
+}

--- a/ResistorWatch/WatchModelContainer.swift
+++ b/ResistorWatch/WatchModelContainer.swift
@@ -1,0 +1,44 @@
+import Foundation
+import SwiftData
+
+/// Builds the watch-side SwiftData `ModelContainer`.
+///
+/// App Groups do NOT bridge iPhone and Apple Watch (they are separate devices),
+/// so the watch CANNOT open the phone's app-group store. Instead the watch keeps
+/// its OWN local store inside its own container directory, configured against the
+/// SAME CloudKit container (`iCloud.com.resistor.app`). CloudKit — not
+/// WatchConnectivity, not App Groups — is what makes a watch log appear on the
+/// phone and vice versa: each device writes locally and the private database
+/// syncs whenever it can.
+///
+/// The schema MUST include all four models so the watch store matches the phone's
+/// CloudKit schema exactly.
+enum WatchModelContainer {
+
+    /// CloudKit container identifier shared with the phone app. Must match the
+    /// `com.apple.developer.icloud-container-identifiers` entitlement.
+    static let cloudKitContainerID = "iCloud.com.resistor.app"
+
+    /// The schema shared with the phone. Keep in sync with the app's models.
+    static var schema: Schema {
+        Schema([
+            Habit.self,
+            TemptationEvent.self,
+            UserSettings.self,
+            ContextTag.self
+        ])
+    }
+
+    /// Builds the production CloudKit-backed container. The store lives at the
+    /// default Application Support location inside the watch app's own container
+    /// directory (a normal, non-app-group URL). Throws if the container cannot
+    /// be created so the caller can fall back to the count-unavailable state.
+    static func makeContainer() throws -> ModelContainer {
+        let configuration = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: false,
+            cloudKitDatabase: .private(cloudKitContainerID)
+        )
+        return try ModelContainer(for: schema, configurations: [configuration])
+    }
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -35,6 +35,7 @@ Comprehensive design document for Resistor, an iOS habit-tracking app that logs 
 3. Show simple trends over time: frequency changes, time-of-day spikes, day-of-week patterns.
 4. Capture the outcome (resisted / gave in) of each logged temptation without adding any step to the single-tap log, so the Insights outcome breakdown reflects real behavior instead of "Not recorded".
 5. Let a user log a resisted temptation for a chosen habit from the Home Screen in one tap, without opening the app, via a configurable WidgetKit widget (post-v1; see Quick-Log Widget under User Flows).
+6. Let a user log a resisted temptation from an Apple Watch in one tap, without their phone present, with the event syncing to the phone via CloudKit (post-v1; see Watch Quick-Log under User Flows). The wrist is the lowest-friction surface for the core action — raise wrist, one tap, done.
 
 ### Non-Goals for v1.0
 
@@ -231,6 +232,80 @@ Edge cases:
   on the next timeline reload (after a widget tap, or WidgetKit's normal refresh
   cadence). The count is never used to make a logging decision, so staleness is
   cosmetic, never a correctness risk.
+
+### Flow 6: Watch Quick-Log (Apple Watch, wrist-native one-tap log)
+
+A watchOS companion app whose single job is the fastest possible log of a
+resisted temptation from the wrist. The watch is the ideal surface for the core
+action: temptation hits → raise wrist → one tap → done, no phone needed. It is
+the wrist-native twin of the Home Screen quick-log widget (Flow 5) — a third
+entry point to the core loop (Flow 1), not a new feature surface. The event
+written is identical in shape to a tap-logged event and to a widget-logged event:
+`occurredAt = now`, `intensity = nil`, `outcome = "resisted"`, no context tags,
+produced by the shared `TemptationLogger.logResisted(...)` that the app and widget
+already use.
+
+Fixed product decisions for v1 (the watch ships deliberately small):
+- **One tap = one resisted log.** The primary watch screen is a single large
+  log control for one habit. A tap writes exactly one `TemptationEvent` with the
+  resisted default. No outcome choice, no intensity, no context tags, no
+  confirmation banner, no undo — those live in the phone app (correction via
+  History event detail, UC-O4; deletion via swipe-to-delete in History).
+- **Success is confirmed by the Taptic Engine.** The watch's haptic is the
+  in-the-moment confirmation channel (the watch is a separate haptic stack from
+  the phone; this is unaffected by the phone-side haptics bug, issue #48). A
+  brief on-screen acknowledgment of the log accompanies the haptic; it carries no
+  motivational or celebratory copy.
+- **Today's resisted count for the logged habit** is shown at rest, matching the
+  phone's "Today: {n} logged" definition (events with `occurredAt` on the current
+  day for that habit).
+
+1. User raises wrist and opens the Resistor watch app (or it is already
+   foregrounded).
+2. The watch shows the habit it logs to (name/icon) and today's resisted count
+   for that habit.
+3. User taps the log control once. One `TemptationEvent` is created for that
+   habit with the resisted default.
+4. The watch fires a success haptic and shows a brief, neutral acknowledgment;
+   the today count increments.
+5. The event syncs to the phone (and any other device on the account) via
+   CloudKit. Once synced, it appears in the phone's Insights and History like any
+   other event.
+
+**Which habit does the watch log to?** v1 logs to the user's **default habit**
+(`UserSettings.defaultHabitId`), falling back to the single habit if only one
+exists. On-watch habit *switching* (a carousel/picker on the wrist) is **Later**
+(see Scope). This keeps v1 to one screen and one tap. If the user has multiple
+habits and no default set, the watch logs to a deterministic first habit and
+names it on screen so the target is never ambiguous (it never logs to an
+unnamed/"current" habit silently).
+
+Edge cases:
+- **Phone not present / not reachable.** The watch logs independently into its
+  own local store; the event syncs to the phone later via CloudKit. v1 does **not**
+  depend on a live phone connection (WatchConnectivity) for logging — see the
+  CloudKit-sync constraint flag below. "Log on watch → appears on phone after
+  CloudKit sync" is the v1 acceptance frame, not "log on watch → instantly on
+  phone."
+- **No habits configured.** The watch cannot create a habit (habit creation stays
+  on the phone). It shows a neutral non-loggable state directing the user to add a
+  habit on the phone; a tap does not write a stray event.
+- **Default habit archived or deleted.** The watch's target no longer resolves to
+  a live, non-archived habit; it shows a non-loggable "habit unavailable" state
+  (parallel to the widget's needs-reconfiguration state) and a tap does not log.
+  If another non-archived habit exists, v1 may fall back to the deterministic
+  first habit (named on screen); choosing fall-back vs. blocking is a ux-designer
+  call so long as the watch never logs to an unnamed target.
+- **Local store unreadable on watch.** If the watch's local SwiftData store
+  cannot be opened (e.g. first launch mid-sync), the count is unknown; the watch
+  shows a count-unavailable state. As with the widget, a tap must not silently
+  drop the event nor write a duplicate.
+- **Rapid repeated taps.** Each deliberate tap is a real event (two urges = two
+  events), consistent with the Log screen and widget. An accidental double-fire of
+  one physical tap is debounced so one tap yields one event.
+- **Offline.** Offline is normal. A write made offline persists locally on the
+  watch and syncs when connectivity returns, exactly as in-app and widget logging
+  do.
 
 ---
 
@@ -1153,6 +1228,496 @@ app motion.
 - Long habit names wrap (small, 2 lines) or scale (medium, 1 line) — never hard
   truncate with an ellipsis on the name itself.
 
+### WATCH: Watch Quick-Log (Apple Watch app)
+
+A standalone watchOS app (`WatchKit`/SwiftUI for watchOS, system frameworks only)
+whose single screen logs a resisted temptation for one habit in one tap. It is a
+third entry point to the core loop (Flow 1 / Flow 6), the wrist-native twin of the
+W1 widget. The watch reuses the shared `TemptationLogger.logResisted(...)` and
+writes to a watch-side SwiftData + CloudKit container that mirrors the same
+CloudKit container the phone uses (`iCloud.com.resistor.app`); parity comes from
+**CloudKit sync between devices, not the App Group** (see constraint flag).
+
+Fixed product decisions (not open for design re-litigation):
+- **Single-screen, single-tap.** One large log control for one habit. A tap fires
+  the shared logger; no outcome/intensity/context capture on the watch.
+- **Logs to the default habit.** The watch targets `UserSettings.defaultHabitId`
+  (falling back to the sole habit, then a deterministic first habit, always named
+  on screen). On-watch habit switching is out of v1 (Later).
+- **Taptic confirmation + brief neutral acknowledgment.** The success haptic is
+  the primary confirmation; any on-screen acknowledgment is clinical (e.g.
+  "Logged"), never celebratory.
+- **No notifications, no complication, no undo, no correction on the watch.**
+  Correction (Gave in) and deletion (undo) happen in the phone app. Complication
+  is Later.
+
+#### Watch Quick-Log (use cases)
+
+The watch exists to make the core action reachable when the phone is not — a run,
+the gym, a pocket-free moment — and to make logging require nothing more than a
+glance and a tap. This requires **no schema change**: the event written is
+identical to an in-app or widget tap log. The new infrastructure is a watchOS app
+target plus a watch-side SwiftData + CloudKit store on the same CloudKit
+container; data parity with the phone is achieved by CloudKit sync, since App
+Groups do not bridge separate devices.
+
+**UC-WATCH-1 — One-tap resisted log from the wrist.**
+As someone in the urge moment without my phone, I want to log that I resisted
+straight from my watch so that I capture the moment regardless of where my phone
+is.
+Acceptance criteria:
+- Tapping the watch log control creates exactly one `TemptationEvent` bound to the
+  watch's target habit, with `outcome = "resisted"`, `intensity = nil`, and an
+  empty context-tag array (the shared `TemptationLogger.logResisted` default).
+- The phone app is not required to be present, awake, or reachable for the log to
+  succeed.
+- The event is identical in shape to a single in-app tap log and to a widget log.
+- After the tap, the watch's displayed today count for that habit increments.
+
+**UC-WATCH-2 — Log on watch appears on phone after CloudKit sync.**
+As someone who logs on my watch, I want the event to show up on my phone so that my
+Insights and History stay complete across devices.
+Acceptance criteria:
+- An event logged on the watch is persisted to the watch's local store
+  immediately (offline-safe).
+- Once both devices have network and CloudKit has synced, the watch-logged event
+  appears in the phone's Insights outcome breakdown (as "Resisted") and in History
+  for that habit, indistinguishable from a phone-logged event.
+- The acceptance frame is "appears on phone **after CloudKit sync**," not instant
+  cross-device appearance; no live phone connection is required.
+- No duplicate event is created on the phone when the watch event syncs in (the
+  event has its own stable `id`; CloudKit reconciles it as one record).
+
+**UC-WATCH-3 — At-rest display names the target and shows today's count.**
+As someone glancing at the watch, I want it to show which habit it logs and how
+many times I've logged today so that the tap target is unambiguous.
+Acceptance criteria:
+- The watch shows the target habit's name (and icon where space allows) and today's
+  resisted count for that habit.
+- The count reflects events with `occurredAt` on the current day for that habit,
+  matching the phone's "Today: {n} logged" definition.
+- The count may lag the live store between syncs; it reconciles on the next
+  successful read and is never used to decide whether to log.
+
+**UC-WATCH-4 — Success haptic confirms the log.**
+As someone who just tapped, I want a wrist haptic so that I know the log
+registered without having to read the screen.
+Acceptance criteria:
+- A successful log fires a watch Taptic Engine haptic (a single neutral success
+  feedback, e.g. a `WKHapticType.success`-class signal — the exact type is a
+  ux/implementer detail).
+- The haptic fires only on a successful write; a tap in a non-loggable state (no
+  habit, habit unavailable) does not fire the success haptic.
+- The haptic is not motivational or celebratory in character; it is a confirmation
+  signal. No sound. No notification is posted (see constraint flag).
+
+**UC-WATCH-5 — Non-loggable state does not log.**
+As someone whose watch has no valid target habit, I want a tap to never create a
+stray or misattributed event so that my data stays trustworthy.
+Acceptance criteria:
+- With zero non-archived habits, the watch shows a non-loggable state directing the
+  user to add a habit on the phone; a tap does not write an event and no habit can
+  be created from the watch.
+- If the target (default) habit was archived or deleted, the watch shows a
+  "habit unavailable" state; a tap does not write to the dead habit. If the watch
+  falls back to another non-archived habit, it names that habit on screen before a
+  tap can log to it.
+- If the watch's local store cannot be read on launch, the count shows a
+  count-unavailable state; the watch never displays a false `0`.
+
+**UC-WATCH-6 — One tap yields exactly one event.**
+As someone tapping quickly, I want a single physical tap to log exactly once so
+that I don't get phantom double-counts.
+Acceptance criteria:
+- A single tap creates exactly one event; an accidental double-fire of that one tap
+  is debounced so it does not create two events.
+- Two deliberate, separate taps create two events (two urges = two events),
+  consistent with the Log screen and widget rapid-tap behavior.
+- An offline write persists locally on the watch and syncs later; it is never
+  silently dropped and never duplicated on sync.
+
+#### Watch Quick-Log (exact copy)
+
+All strings clinical, no motivational/emotional language, no emoji, honoring the
+Forbidden Language table. Final strings for the implementer; exact placement and
+sizing are a ux-designer/implementer detail for the small watch canvas.
+
+| Element | Final string |
+|---------|--------------|
+| Habit name | The habit's own name, verbatim; never decorated, never prefixed |
+| At-rest count | `Today: {n} logged` (or the space-constrained `{n} today` on the smallest watch widths — ux-designer call, same trade-off as the widget) |
+| Log control | No "tap to log" hint in the configured state; the log control is the affordance (consistent with the in-app and widget no-hint convention) |
+| Post-log acknowledgment | `Logged` (matches the phone banner's State-1 status word; neutral, not celebratory) |
+| No-habit state — primary | `No habit to log` |
+| No-habit state — secondary | `Add a habit on your phone` |
+| Habit-unavailable state — primary | `Habit unavailable` |
+| Habit-unavailable state — secondary | `Set a default habit on your phone` |
+| Count-unavailable state | `Count unavailable` |
+| Forbidden | No "Great job", "Streak", "You resisted!", success/celebration copy, or emoji anywhere on the watch |
+
+#### Watch Quick-Log (interaction and visual spec)
+
+Build-ready spec for the watchOS app. New watchOS app target (SwiftUI for
+watchOS, system frameworks only — `SwiftUI`, `SwiftData`, `WatchKit` for the
+Taptic call); no new screen in the phone app, no navigation push, no data-model
+or schema change. The watch reuses the existing habit color system
+(`Color(hex:)`) and semantic colors only, and the shared
+`TemptationLogger.logResisted(...)`. Everything below is sized for the watch
+canvas (designed against the 41/45/49mm range; the layout is fluid, not
+pixel-pinned — final spacing nudges are a ui-iterator follow-up, called out at
+the end).
+
+##### Single screen, no navigation
+
+The watch app is exactly one screen — no `NavigationStack`, no tabs, no Digital
+Crown scroll target in v1 (there is nothing to scroll; the whole control fits one
+watch face). The screen is the log control plus its surrounding identity text.
+This honors the "single-screen, single-tap" fixed product decision and keeps the
+wrist interaction to: raise wrist → one tap → done.
+
+- **No `ScrollView`.** All content fits within the safe area at Default Dynamic
+  Type. At the largest watch Dynamic Type sizes the content may exceed one screen;
+  wrap the whole layout in a `ScrollView` *only as an overflow safety net* (it
+  does not scroll at normal sizes), so large-text users can still reach the count
+  line below the button. This mirrors the watch HIG pattern of a non-scrolling
+  primary control that becomes scrollable only when text forces it.
+- **Digital Crown:** unused in v1 — no rotation target, no focus value. (A future
+  on-watch habit switcher, "Later", is the natural Crown owner; do not wire it
+  now.)
+- **Safe area:** use the system default; do not fight the watch's curved-corner
+  inset. Let SwiftUI's default `.scenePadding()`-equivalent margins apply. The
+  log button is centered, so the curved corners never clip it.
+
+##### Layout — the primary tap target
+
+The screen is a vertical stack, the **log button dominating the center**, with the
+habit identity above it and today's count below it:
+
+```
+┌───────────────────────┐
+│       Sugar           │   ← habit name (identity, top)
+│                       │
+│    ╭───────────────╮  │
+│    │      ◉        │  │   ← LOG BUTTON: large filled
+│    │    (icon)     │  │     habit-color circle, centered,
+│    │               │  │     the dominant tap target
+│    ╰───────────────╯  │
+│                       │
+│   Today: 3 logged     │   ← today's count (below)
+└───────────────────────┘
+```
+
+- **Container:** `VStack(spacing: 8)` centered in the screen. Order top→bottom:
+  habit name, log button, count line.
+- **Habit name (top, identity):** `Text(habit.name)`, `.font(.headline)`,
+  `.fontWeight(.semibold)`, `.foregroundStyle(.primary)`,
+  `.multilineTextAlignment(.center)`, `.lineLimit(2)`,
+  `.minimumScaleFactor(0.8)`. Names wrap to two centered lines, then scale
+  slightly, rather than truncating. It sits above the button so the user reads
+  *what they are about to log* before tapping — the target is never ambiguous
+  (UC-WATCH-3, UC-WATCH-5 fall-back requirement that the target is always named).
+- **Log button (center, the tap target):** a single large filled circle — the
+  wrist-native equivalent of the phone's "Log Temptation" primary button and the
+  widget's filled habit-color card. The whole circle is one
+  `Button(action: log)`:
+  - Shape: `Circle()` fill = `habitColor` (full saturation), sized to roughly
+    **60–66% of the screen width** (the largest comfortably-centered circle that
+    leaves room for the name above and count below). On a 45mm watch this is
+    ~120pt diameter; let it be `.frame(maxWidth: .infinity)`-driven with an
+    `.aspectRatio(1, contentMode: .fit)` inside a width-capped container rather
+    than a hardcoded diameter, so it scales across watch sizes. It is far larger
+    than the 44pt minimum — this is a deliberately oversized, gloved/eyes-off
+    target.
+  - Glyph: `Image(systemName: habit.iconName ?? "circle.fill")`, centered,
+    `.font(.system(size: 36, weight: .semibold))`, `.foregroundStyle(.white)`
+    (white-on-habit-color, matching the phone primary button's white-on-accent
+    treatment). The icon names the habit a second way (with the text above), so
+    color is never the only identity carrier.
+  - `.buttonStyle(.plain)` so watchOS does not draw its own bezel over the custom
+    circle; the system still applies its built-in touch-down dim, which is the
+    press feedback (see Motion).
+  - There is **no text inside the button** ("Log Temptation" would crowd the small
+    circle and the action is self-evident from the filled habit-color target). The
+    "log control is the affordance, no hint text" rule from the widget carries
+    over verbatim.
+- **Count (below, glanceable status):** `Text("Today: \(n) logged")`,
+  `.font(.footnote)`, `.foregroundStyle(.secondary)`, `.lineLimit(1)`,
+  `.minimumScaleFactor(0.7)`. On the narrowest widths / largest Dynamic Type
+  where the full form will not fit one line even scaled, fall back to the terse
+  `Text("\(n) today")` (same trade-off the widget makes between its medium
+  `Today: {n} logged` and small `{n} today`). Decide at build time with a
+  `ViewThatFits` between the two strings: prefer `Today: {n} logged`, fall back to
+  `{n} today`. The count is below the button so it never competes with the tap
+  target; it is status, not the action.
+
+##### How habit color is used on the small canvas
+
+- The **button fill is the one bold use of `habitColor`** — full saturation,
+  white glyph on top. This is the single anchor of habit identity and the primary
+  affordance ("this filled colored circle logs").
+- The screen **background stays the system default** (`Color(.black)` on the
+  always-OLED watch; do not paint a habit-tinted full-bleed background — the watch
+  canvas is black for power and contrast, and a tint would fight the OLED black
+  and reduce the button's pop). Unlike the widget's faint 12% card wash, the watch
+  leans on a pure-black field with one saturated control, which is the higher-
+  contrast, more glanceable choice on the small screen.
+- Text (name, count) uses `.primary` / `.secondary` semantic colors, never the
+  habit color, so they stay legible against black regardless of hue.
+- `habitColor = Color(hex: habit.colorHex ?? "#007AFF") ?? .blue` — the exact
+  existing pattern. Never the user *accent* color (the watch is habit-scoped, and
+  the app-root `.tint()` does not apply in a separate watch target), never a
+  hardcoded brand color.
+
+##### States
+
+The watch has six states. Loggable states show the filled habit-color button;
+non-loggable states **replace the button with a de-emphasized, un-fillable glyph**
+so the user is never invited to tap a surface that will not log (the same
+loggable-vs-not affordance signal the widget uses: filled habit-color = loggable,
+flat secondary = not).
+
+###### State (a): At-rest / loggable (default)
+
+The default, described in Layout above: name (top), filled habit-color log button
+(center), `Today: {n} logged` (below). The button is enabled; a tap logs (UC-WATCH-1).
+
+###### State (b): Logging / in-flight
+
+The write is synchronous and effectively instant (`TemptationLogger.logResisted`
++ `try? save()` to the local store), so there is **no spinner and no separate
+visible "in-flight" screen**. Tapping moves directly from at-rest to the success
+acknowledgment. To guarantee one-tap-one-event under a fast double-fire
+(UC-WATCH-6), the button is **disabled for the debounce window** the instant it is
+tapped:
+
+- On tap: set `isLogging = true`, perform the write, fire the success haptic,
+  show the acknowledgment, then re-enable after the debounce window (~800ms,
+  matching the widget's debounce) via a cancellable task. A second physical
+  contact inside that window hits a disabled button and does nothing → one tap =
+  one event. Two deliberate taps spaced beyond the window = two events.
+- During `isLogging` the button's fill drops to `habitColor.opacity(0.5)` (a brief
+  pressed-looking dim) so a too-fast second tap visibly lands on a non-primed
+  target. This is the only "in-flight" visual and it lasts only the debounce
+  window.
+
+###### State (c): Success acknowledgment ("Logged")
+
+Mirrors the phone banner's transient-confirmation philosophy (a brief, neutral,
+self-dismissing acknowledgment) but watch-appropriate — the Taptic haptic is the
+*primary* confirmation (UC-WATCH-4); the on-screen text is secondary and exists
+for the eyes-on case.
+
+- **How "Logged" appears:** an overlay centered over (or just below) the button
+  region — `Text("Logged")`, `.font(.headline)`, `.fontWeight(.semibold)`,
+  `.foregroundStyle(.primary)`, paired with `Image(systemName: "checkmark.circle.fill")`
+  `.foregroundStyle(.green)` (the resisted/logged semantic green, identical to the
+  phone banner State-1 glyph). Lay them out as an `HStack(spacing: 6)` or stack the
+  check above the word — implementer's call on the small canvas, but the green check
+  + "Logged" word must read as one unit.
+- **The count updates underneath simultaneously:** `Today: {n} logged` increments
+  to the new `n` as the acknowledgment shows, so when the acknowledgment clears the
+  user is back at at-rest with the new count already in place.
+- **Duration / auto-resolve:** the acknowledgment is transient — it auto-dismisses
+  after **1.2s**, then the screen returns to state (a). 1.2s is shorter than the
+  phone banner's 5s because the watch acknowledgment carries **no actionable
+  controls** (no Gave-in, no Undo — those live on the phone), so it only needs to
+  register "it worked," not hold a correction window. A wrist glance is brief by
+  nature; a long-lived banner would overstay. Implement with a cancellable
+  `DispatchWorkItem` / `Task.sleep`, not a layout that blocks re-tapping — the
+  button re-enables on the debounce window (~800ms), so a user with a genuine second
+  urge can tap again *before* the acknowledgment text finishes fading (the second
+  tap simply restarts the acknowledgment and re-increments). The acknowledgment is a
+  display layer over a still-live button, not a modal.
+- **Transition:** the check + "Logged" fade/scale in (see Motion); the count number
+  changes in place. No celebratory motion, no confetti, no checkmark "draw"
+  flourish — a plain fade is the clinical choice.
+
+###### State (d): No habit (zero non-archived habits)
+
+The watch cannot create a habit; it directs the user to the phone (UC-WATCH-5). A
+tap does nothing (no button, no log, no haptic).
+
+- **Replace the button** with `Image(systemName: "square.dashed")`,
+  `.font(.system(size: 36))`, `.foregroundStyle(.secondary)` — the same
+  "empty slot" glyph language as the widget's unconfigured state, **not** wrapped
+  in a `Button`.
+- Primary text (where the habit name would be): `Text("No habit to log")`,
+  `.font(.headline)`, `.foregroundStyle(.primary)`, `.multilineTextAlignment(.center)`,
+  `.lineLimit(2)`.
+- Secondary text (where the count would be): `Text("Add a habit on your phone")`,
+  `.font(.footnote)`, `.foregroundStyle(.secondary)`,
+  `.multilineTextAlignment(.center)`, `.lineLimit(2)`.
+- No habit-color anywhere (there is no habit). The de-emphasized secondary glyph
+  signals non-loggable.
+
+###### State (e): Habit unavailable (default/target habit archived or deleted)
+
+The stored target no longer resolves to a live, non-archived habit, **and** the
+watch has no other non-archived habit to fall back to (if one *does* exist, v1
+falls back to the deterministic first habit and renders state (a) with that
+habit's name — it never silently blocks when a valid target exists; it also never
+logs to an unnamed target). When there is genuinely no valid target:
+
+- **Replace the button** with `Image(systemName: "exclamationmark.triangle")`,
+  `.font(.system(size: 36))`, `.foregroundStyle(.secondary)` (**not** `.red` — this
+  is a setup condition, not a destructive error; `.secondary` keeps it calm and
+  clinical, matching the widget's needs-reconfiguration glyph). Not a `Button`.
+- Primary text: `Text("Habit unavailable")`, `.font(.headline)`,
+  `.foregroundStyle(.primary)`, centered, `.lineLimit(2)`.
+- Secondary text: `Text("Set a default habit on your phone")`, `.font(.footnote)`,
+  `.foregroundStyle(.secondary)`, centered, `.lineLimit(2)`.
+- Do **not** show the dead habit's name or color — the binding is stale; showing
+  it would imply it still logs there.
+
+###### State (f): Count unavailable (local store unreadable)
+
+The watch's local SwiftData store could not be read on launch (e.g. first launch
+mid-sync), so today's count is unknown. The watch **must never show a false `0`**
+(UC-WATCH-5). Two sub-cases:
+
+- **Habit identity known, count unknown** (the common case — the target habit
+  resolves from settings/relationship even though the event count query failed):
+  render state (a)'s layout — name on top, **the filled habit-color log button
+  stays** (logging still works; the write persists locally and syncs later, exactly
+  like offline) — but replace the count line with `Text("Count unavailable")`,
+  `.font(.footnote)`, `.foregroundStyle(.secondary)`. The button remains loggable
+  because dropping the write would violate UC-WATCH-6's offline-persist guarantee;
+  only the *display* of the count is unavailable, not the ability to log.
+- **Nothing resolves** (store so unreadable the target habit cannot be determined):
+  fall back to state (e) "Habit unavailable" appearance with no button, because a
+  tap cannot be guaranteed to route to a real habit. Prefer the loggable sub-case
+  whenever the target habit identity is known.
+
+##### Interaction and motion
+
+- **Tap-only — the elaborate phone hold-to-log ramp is dropped on the watch.**
+  **Recommendation (decided here): tap-only.** The phone's multi-layer hold effect
+  (3s ramp, glow, radiating ring, Core Haptics intensity escalation) is explicitly
+  **not** ported to the watch. Rationale: (1) the hold ramp exists to add a moment
+  of deliberation/weight to the phone log — the watch's entire reason for being is
+  *speed* ("raise wrist, one tap, done"), so a 3-second hold would directly
+  undermine its purpose; (2) the watch's small screen has no room for the layered
+  glow/ring visual system; (3) Core Haptics continuous patterns are a phone stack —
+  the watch uses discrete `WKHapticType` signals, not a ramped continuous engine.
+  A watch tap is a single discrete log. There is **no hold gesture on the watch.**
+- **Tap behavior:** one tap on the filled circle → `TemptationLogger.logResisted`
+  for the target habit → success haptic → "Logged" acknowledgment (state c) →
+  auto-return to at-rest after 1.2s with the incremented count.
+- **Debounce feel:** instantaneous to the user — the button dims (state b) and is
+  disabled for ~800ms, so an accidental double-contact is swallowed silently. There
+  is no error, no shake, no "too fast" message; the second contact simply has no
+  effect. A deliberate second tap after the window logs again normally.
+- **Success animation:** the green check + "Logged" **fade and gently scale in**
+  (from `0.9 → 1.0` scale, opacity `0 → 1`) over ~0.15s, hold, then fade out over
+  ~0.2s as the screen returns to at-rest. The button itself does a brief settle
+  (the touch-down dim releasing). Keep it minimal and non-celebratory — a plain
+  fade, no bounce, no particle effect, no checkmark stroke-draw.
+- **Reduce Motion (required) —** `@Environment(\.accessibilityReduceMotion)`:
+  - Success acknowledgment: **no scale, no fade.** The check + "Logged" appear and
+    disappear **instantly** (mutate state outside `withAnimation`); the count number
+    swaps instantly. The acknowledgment still shows for its 1.2s dwell — Reduce
+    Motion removes the *animation*, not the acknowledgment itself.
+  - Button in-flight dim: with Reduce Motion on, snap the opacity change rather than
+    animating it (it is already a near-instant ~800ms state, so this is mostly a
+    no-op, but do not wrap it in `withAnimation` when Reduce Motion is on).
+  - This matches the established Reduce Motion pattern app-wide: instant state
+    change, no spring/slide/cross-fade.
+
+##### Haptic spec
+
+- **Success haptic (UC-WATCH-4):** `WKInterfaceDevice.current().play(.success)` —
+  the standard watchOS success Taptic. Chosen over `.click` because the log is a
+  meaningful completion (an event was written), and `.success` is the system's
+  conventional "the thing you did worked" signal — neutral and confirmatory, not
+  celebratory (it is a standard system haptic, carries no copy, no sound). It is
+  **not** `.notification` (that connotes an alert/nudge, which this is not) and not
+  `.click` (too slight for a completion the user may not be looking at).
+- **Fire only on a successful write.** Gate the haptic on
+  `TemptationLogger.logResisted` returning success (the same `guard` the phone uses
+  before `triggerConfirmation()`). If the write fails, no haptic and no "Logged"
+  acknowledgment.
+- **No haptic in non-loggable states.** A tap in state (d) "no habit" or state (e)
+  "habit unavailable" produces **no haptic at all** — there is no button to tap, so
+  there is nothing to acknowledge. Do not play `.failure` or `.click` on a
+  non-loggable tap; silence is the correct, clinical response (a haptic there would
+  imply something happened).
+- **No sound, ever.** `WKHapticType` is Taptic-only; do not add `WKAudioFilePlayer`
+  or any audio. No notification is posted (the watch never posts a local
+  notification — consistent with the app-wide no-notifications rule).
+- The watch Taptic Engine is a **separate haptic stack from the phone**; this spec
+  is unaffected by the open phone-side haptics bug (#48).
+
+##### Accessibility (watch)
+
+- **VoiceOver — log button (states a, f-loggable):**
+  - Label: `"{Habit}, {n} logged today"` (use `"1 logged today"` / `"0 logged
+    today"`; in the count-unavailable sub-case the label is `"{Habit}, count
+    unavailable"`). Always speak the full unambiguous form even when the visual
+    count is the terse `{n} today` — same principle as the widget and the
+    time-of-day hourly labels.
+  - Trait: `.isButton`.
+  - Hint: `"Logs a resisted temptation."`
+  - On activate (VoiceOver double-tap): logs, exactly as a touch tap, including the
+    success haptic. After the write, post
+    `WKInterfaceDevice`-independent VoiceOver feedback by re-reading the updated
+    label on re-focus; additionally, because the acknowledgment is transient, post
+    `UIAccessibility.post(notification: .announcement, argument: "Logged")` so a
+    VoiceOver user hears confirmation without seeing the fade. (watchOS supports
+    `UIAccessibility.post`; unlike the widget extension, the watch app *can* post
+    announcements.)
+- **VoiceOver — non-loggable states (d, e):** the whole screen is **one combined
+  element** (`.accessibilityElement(children: .combine)`), **no `.isButton`
+  trait**, so a non-visual user is never told they can log when they cannot.
+  - State (d) label: `"No habit to log. Add a habit on your phone."`
+  - State (e) label: `"Habit unavailable. Set a default habit on your phone."`
+  - No "logs" hint (a tap does nothing). No on-activate log.
+- **VoiceOver — count line** when read separately (state a): the count is folded
+  into the button's combined label (above), so it is **not** a second focus stop —
+  the button label already speaks `"{n} logged today"`. Do not duplicate it as an
+  independent element.
+- **Dynamic Type on the watch:** all text uses watch text styles (`.headline`,
+  `.footnote`) — no hardcoded font sizes except the button glyph, which uses
+  `.system(size: 36, …)` and is an SF Symbol (it scales acceptably and is not text).
+  The habit name uses `.minimumScaleFactor(0.8)` + `.lineLimit(2)`; the count uses
+  `ViewThatFits` (`Today: {n} logged` → `{n} today`) + `.minimumScaleFactor(0.7)`
+  so it never clips. At the largest watch Dynamic Type sizes, the overflow
+  `ScrollView` safety net (see "Single screen") lets the count remain reachable
+  below the button. **No fixed heights** on any text container — the button is the
+  only fixed-aspect element, and it is sized by width fraction, not a clipping
+  height. Test at the watch's smallest and largest Dynamic Type sizes plus the
+  largest watch (49mm) and smallest (41mm).
+- **Reduce Motion:** as specified under Motion — instant acknowledgment, no scale/
+  fade, no animated dim.
+- **Contrast:** white glyph on full-saturation habit color, and `.primary` /
+  `.secondary` text on the OLED-black field, both clear WCAG AA. The habit color is
+  user-chosen from a vetted preset list; the white-on-color button glyph is the
+  same white-on-saturated-color treatment the phone primary button uses and passes
+  in both. (A ui-iterator screenshot pass on-device is the right place to verify
+  each of the 10 preset hues against white — flagged as follow-up below.)
+
+##### Complication (forward-compat note, out of v1 scope)
+
+A complication is **Later** (out of v1 per scope) — do not build it now. One
+structural note so the data layer does not have to be reworked when it lands:
+have the watch app read today's count and the target-habit identity through a
+small, reusable provider (e.g. a `WatchLogStore` / view-model that exposes
+`targetHabit` and `todayResistedCount(for:)` off the shared SwiftData container),
+rather than computing those inline in the view. A future
+`CLKComplicationDataSource` / WidgetKit-on-watch `TimelineProvider` would consume
+the **same** provider to render "today's count" on a complication face. Keeping the
+count/identity computation out of the View now means the complication is a new
+*presentation* over an existing data path, not a data rewrite. No complication UI,
+entitlement, or `ClockKit` code in v1.
+
+##### Follow-ups for ui-iterator (not done here)
+
+- On-device screenshots of states (a), (c)-success, (d), (e), (f) at 41mm / 45mm /
+  49mm, light is N/A (watch is always dark), to verify the button diameter fraction,
+  vertical balance of name/button/count, and the "Logged" acknowledgment placement
+  by eye.
+- Verify white button glyph contrast against each of the 10 preset habit hues
+  on-device.
+
 ---
 
 ## Visual Design System
@@ -1233,6 +1798,15 @@ All interactive elements meet 44x44pt minimum tap target.
 
 **Stat Card:** Caption + large value + subtitle. Surface background, 12pt corner radius.
 
+**Watch Log Button:** A large filled `Circle()` (habit color, full saturation),
+~60–66% of screen width, centered, with a white SF Symbol habit glyph (36pt). The
+single wrist tap target — the watch-native twin of the phone primary "Log
+Temptation" button and the widget's filled habit-color card. `.buttonStyle(.plain)`;
+system touch-down dim is the only press feedback; no text inside, no hint label. In
+non-loggable watch states it is replaced by a de-emphasized `.secondary` glyph
+(`square.dashed` / `exclamationmark.triangle`), not a button, so the surface never
+reads as primed to log.
+
 **Confirmation Banner:** A status glyph + status word on the left; a correction
 control and a destructive control on the right. Full-width with horizontal padding.
 System background, 12pt corner radius, subtle shadow. Slides from top, auto-hides 5s.
@@ -1276,6 +1850,8 @@ Dark mode is the default. Light mode must also work.
 | Tap | History event-detail Outcome picker | Open menu, select outcome; persist to that event | — |
 | Tap | Quick-Log Widget card (configured / store-unavailable state) | Fire `LogResistedIntent`: write one resisted event for the bound habit, reload timeline | ~800ms per-config debounce against accidental double-fire |
 | Long press | Quick-Log Widget card (any state) | System Edit Widget sheet (habit binding) — system gesture, not app-drawn | System default |
+| Tap | Watch log button (loggable states a / f-loggable) | Fire `TemptationLogger.logResisted` for the target habit; play `.success` Taptic; show "Logged" acknowledgment; increment count | ~800ms debounce (button disabled during window) against accidental double-fire |
+| Tap | Watch screen (non-loggable states d / e) | No-op — no log, no haptic (no button rendered) | — |
 
 ### Drag Gesture (Habit Card)
 
@@ -1290,6 +1866,14 @@ Dark mode is the default. Light mode must also work.
 Single haptic: log temptation only. `UIImpactFeedbackGenerator`, `.medium` style, on button tap before sheet.
 
 No haptics on navigation, sheets, or secondary actions.
+
+**Watch (separate Taptic stack, unaffected by phone haptics bug #48):** success
+log only — `WKInterfaceDevice.current().play(.success)`, fired solely on a
+successful write (gated on `TemptationLogger.logResisted` returning success).
+**No** haptic on a tap in a non-loggable watch state (no habit / habit
+unavailable), no `.failure`/`.click` fallback, no sound, no notification. The
+phone's Core Haptics continuous hold pattern does **not** exist on the watch
+(tap-only, no hold-to-log).
 
 ### Sheet Presentation
 
@@ -1330,6 +1914,8 @@ Rules:
 | Card snap-back | Spring | 0.3s |
 | Time of Day expand/collapse | Bars cross-fade + height change | 0.25s easeInOut |
 | Time of Day filter-change while expanded | Bar heights interpolate to new counts | 0.25s easeInOut |
+| Watch success acknowledgment ("Logged") | Green check + word fade + gentle scale (0.9→1.0) in, then fade out | 0.15s in / 1.2s dwell / 0.2s out |
+| Watch log button in-flight dim | Fill opacity 1.0→0.5 during ~800ms debounce window | ~800ms |
 | Sheets, tabs, navigation | System default | System |
 
 #### Time-of-Day Drill-Down motion
@@ -1744,6 +2330,10 @@ When enabled:
 - Sheet presentation: system automatic
 - Time of Day expand/collapse and filter-driven recompute: instant chart swap, no
   cross-fade or bar-height interpolation (no `withAnimation`)
+- Watch success acknowledgment: instant appear/disappear — no scale, no fade; the
+  count number swaps instantly. The 1.2s acknowledgment dwell still applies (Reduce
+  Motion removes the animation, not the acknowledgment). The button in-flight dim is
+  snapped, not animated.
 
 ### Color and Contrast
 
@@ -1890,7 +2480,19 @@ Screen widgets, Control Center controls (iOS 18), multi-habit-in-one-widget, and
 showing today's count for a non-configured "default" habit are all deferred (the
 configurable single-habit model is the chosen design).
 
-**Apple Watch App (WatchKit)** — Logging only. Complication shows today's count. Outcome selection. Syncs via iCloud.
+**Watch Quick-Log (watchOS App)** — A standalone watchOS app whose single job is
+the fastest possible one-tap log of a resisted temptation from the wrist, no phone
+needed. Logs to the user's default habit, shows today's resisted count at rest,
+confirms with a Taptic Engine haptic. Reuses the shared
+`TemptationLogger.logResisted(...)`; data parity with the phone comes from
+**CloudKit sync of the same container, not the App Group** (App Groups do not
+bridge separate devices). Full brief: User Flows → Flow 6 and Screens → WATCH.
+**Scope this pass: single-screen, single-tap log to the default habit + today's
+count + success haptic + CloudKit-synced store.** **Out/Later:** a complication,
+on-watch habit switching, outcome/intensity capture on the watch, undo/correction
+on the watch, and a fully phone-less independent install (App Store watch-only
+install) are all deferred. **Constraint-clean:** no notifications/reminders/streaks
+on the watch (the permanent notifications ban holds).
 
 ### Tier 3: Future Consideration
 
@@ -1964,3 +2566,11 @@ Summary of all design decisions made during the design phase.
 | Quick-log widget non-loggable visuals | (b)/(c) drop the habit-color tint and use a muted `square.dashed` / `exclamationmark.triangle` glyph in `.secondary`, no `Button` | The card must not *look* like a primed log button when a tap won't log; `.secondary` (not `.red`) keeps a setup condition calm and clinical |
 | Quick-log widget store-unavailable | Keeps the tap (write enqueues + syncs later), replaces the count with `Count unavailable` / `ellipsis`, keeps habit tint | UC-W5 requires offline writes to persist; only the count *display* is unavailable, so the card stays loggable and never shows a false `0` |
 | Quick-log widget haptics / motion / announcements | None — platform-limited in a widget extension | Widgets can't fire haptics, animate timeline reloads, or post `UIAccessibility` announcements; the count change on reload is the only feedback |
+| Watch app purpose | Single-screen, single-tap resisted log from the wrist (the wrist-native twin of the widget) | The wrist is the lowest-friction surface for the core action; no phone needed in the urge moment |
+| Watch logged habit | Logs to the default habit (`UserSettings.defaultHabitId`), fallback to sole/first habit, always named on screen | Keeps v1 to one screen and one tap; on-watch switching is deferred to Later |
+| Watch action | One tap writes one `resisted` event (intensity nil, no tags) via shared `TemptationLogger.logResisted` | Mirrors the in-app and widget single-tap default (UC-O1 / UC-W1); identical event shape, no schema change |
+| Watch confirmation | Taptic Engine success haptic + neutral on-screen "Logged"; no notification, no banner/undo | The watch is a separate haptic stack (unaffected by phone haptics bug #48); correction/undo live on the phone |
+| Watch data parity | CloudKit sync of the same container (`iCloud.com.resistor.app`), **not** App Group | App Groups do not bridge iPhone↔Watch (separate devices); cross-device parity must come from CloudKit. Primary feasibility dependency for v1 |
+| Watch v1 acceptance frame | "Log on watch → appears on phone **after CloudKit sync**" (not instant, no live phone link required) | Logging must not depend on WatchConnectivity reachability; the watch logs independently and syncs later |
+| Watch vs notifications ban | No collision; the watch is a passive log surface with no push/alert/reminder/streak | The ban is on interruptive notifications; the watch never alerts, schedules, or nudges |
+| Watch scope (out/later) | Complication, on-watch habit switching, outcome/intensity capture, undo/correction, fully phone-less independent install — all deferred | v1 ships the smallest useful wrist surface: one tap, one habit, one haptic, synced |

--- a/scripts/add_watch_target.rb
+++ b/scripts/add_watch_target.rb
@@ -1,0 +1,178 @@
+#!/usr/bin/env ruby
+# Adds the ResistorWatch watchOS Quick-Log companion app target to
+# Resistor.xcodeproj, wires its sources/Info.plist/entitlements/build settings,
+# embeds it into the Resistor iOS app via an "Embed Watch Content" Copy Files
+# phase, makes the iOS app depend on it, and makes the reused model + shared
+# helper files members of the watch target so it compiles against the same
+# CloudKit-compatible @Model types as the phone (NO file duplication).
+#
+# This is a single-target watchOS app (watchOS 9+ style:
+# com.apple.product-type.application, SDKROOT = watchos), NOT the legacy
+# WatchKit app+extension pair.
+#
+# Cross-device note: App Groups do NOT bridge iPhone and Apple Watch. The watch
+# does NOT use the phone's app-group store (SharedModelContainer). It has its own
+# local store wired against the same CloudKit container; CloudKit sync carries
+# logs between devices. Hence this script does NOT add an app-group entitlement
+# to the watch and does NOT add SharedModelContainer.swift to its membership.
+#
+# Idempotent: re-running does not duplicate the target, build phases, file
+# references, memberships, or the shared scheme. Safe to run repeatedly.
+#
+# Requires the `xcodeproj` gem (gem install --user-install xcodeproj).
+
+require "xcodeproj"
+
+ROOT         = File.expand_path("..", __dir__)
+PROJECT_PATH = File.join(ROOT, "Resistor.xcodeproj")
+APP_TARGET   = "Resistor"
+WATCH_TARGET = "ResistorWatch"
+WATCH_DIR    = "ResistorWatch"
+TEAM_ID      = "HBXLU45HR7"
+APP_BUNDLE_ID   = "com.resistor.app"
+WATCH_BUNDLE_ID = "#{APP_BUNDLE_ID}.watchkitapp"
+WATCHOS_DEPLOYMENT_TARGET = "10.0"
+
+# App/source files (relative to repo root) the watch target needs to compile
+# because it reuses the app's @Model types and shared log helper. NOTE: this
+# deliberately EXCLUDES SharedModelContainer.swift (app-group store the watch
+# can't see) — the watch builds its own WatchModelContainer.
+SHARED_APP_FILES = [
+  "Resistor/Models/Habit.swift",
+  "Resistor/Models/TemptationEvent.swift",
+  "Resistor/Models/UserSettings.swift",
+  "Resistor/Models/ContextTag.swift",
+  "Resistor/Extensions/Color+Hex.swift",
+  "Resistor/Shared/TemptationLogger.swift"
+].freeze
+
+project = Xcodeproj::Project.open(PROJECT_PATH)
+
+app = project.targets.find { |t| t.name == APP_TARGET }
+raise "App target #{APP_TARGET} not found" unless app
+
+# ---------------------------------------------------------------------------
+# 1. Create (or reuse) the watchOS app target.
+# ---------------------------------------------------------------------------
+watch = project.targets.find { |t| t.name == WATCH_TARGET }
+created = false
+unless watch
+  watch = project.new_target(
+    :application,
+    WATCH_TARGET,
+    :watchos,
+    WATCHOS_DEPLOYMENT_TARGET,
+    nil,
+    :swift
+  )
+  created = true
+end
+
+watch.build_configurations.each do |config|
+  s = config.build_settings
+  s["PRODUCT_NAME"]                      = "$(TARGET_NAME)"
+  s["PRODUCT_BUNDLE_IDENTIFIER"]         = WATCH_BUNDLE_ID
+  s["CODE_SIGN_STYLE"]                   = "Automatic"
+  s["DEVELOPMENT_TEAM"]                  = TEAM_ID
+  s["CODE_SIGN_ENTITLEMENTS"]            = "#{WATCH_DIR}/#{WATCH_TARGET}.entitlements"
+  s["INFOPLIST_FILE"]                    = "#{WATCH_DIR}/Info.plist"
+  s["GENERATE_INFOPLIST_FILE"]           = "YES"
+  s["INFOPLIST_KEY_CFBundleDisplayName"] = "Resistor"
+  s["INFOPLIST_KEY_WKApplication"]       = "YES"
+  s["INFOPLIST_KEY_WKCompanionAppBundleIdentifier"] = APP_BUNDLE_ID
+  s["INFOPLIST_KEY_UISupportedInterfaceOrientations"] = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown"
+  s["SDKROOT"]                           = "watchos"
+  s["WATCHOS_DEPLOYMENT_TARGET"]         = WATCHOS_DEPLOYMENT_TARGET
+  s["TARGETED_DEVICE_FAMILY"]            = "4"
+  s["SUPPORTED_PLATFORMS"]               = "watchos watchsimulator"
+  s["SUPPORTS_MACCATALYST"]              = "NO"
+  s["SWIFT_VERSION"]                     = "5.0"
+  s["SWIFT_EMIT_LOC_STRINGS"]            = "YES"
+  s["CURRENT_PROJECT_VERSION"]           = "1"
+  s["MARKETING_VERSION"]                 = "1.0.0"
+  s["SKIP_INSTALL"]                      = "YES"
+  s["ENABLE_PREVIEWS"]                   = "YES"
+  s["LD_RUNPATH_SEARCH_PATHS"]           = [
+    "$(inherited)",
+    "@executable_path/Frameworks"
+  ]
+end
+
+# ---------------------------------------------------------------------------
+# 2. Watch's own source group + files (everything under ResistorWatch/*.swift).
+# ---------------------------------------------------------------------------
+group = project.main_group.find_subpath(WATCH_DIR, true)
+group.set_source_tree("<group>")
+group.set_path(WATCH_DIR)
+
+Dir.glob(File.join(ROOT, WATCH_DIR, "*.swift")).sort.each do |path|
+  rel = File.basename(path)
+  file_ref = group.files.find { |f| f.display_name == rel } || group.new_reference(rel)
+  unless watch.source_build_phase.files_references.include?(file_ref)
+    watch.add_file_references([file_ref])
+  end
+end
+
+# Register Info.plist / entitlements as references (not compiled) if absent.
+[["Info.plist"], ["#{WATCH_TARGET}.entitlements"]].each do |name,|
+  next if group.files.any? { |f| f.display_name == name }
+  group.new_reference(name)
+end
+
+# ---------------------------------------------------------------------------
+# 3. Make the reused model/helper files members of the watch target too.
+#    Reuse the existing file references already in the app target — no dupes.
+# ---------------------------------------------------------------------------
+SHARED_APP_FILES.each do |rel|
+  ref = project.files.find { |f| f.real_path.to_s == File.join(ROOT, rel) }
+  unless ref
+    warn "WARNING: shared file reference not found for #{rel}; skipping membership."
+    next
+  end
+  next if watch.source_build_phase.files_references.include?(ref)
+  watch.add_file_references([ref])
+end
+
+# ---------------------------------------------------------------------------
+# 4. Embed the watch app into the iOS app via an "Embed Watch Content" Copy
+#    Files phase (dstSubfolderSpec 16 / path $(CONTENTS_FOLDER_PATH)/Watch).
+# ---------------------------------------------------------------------------
+embed_phase = app.copy_files_build_phases.find do |p|
+  p.name == "Embed Watch Content" ||
+    (p.dst_subfolder_spec.to_s == "16" && p.dst_path.to_s.include?("Watch"))
+end
+unless embed_phase
+  embed_phase = app.new_copy_files_build_phase("Embed Watch Content")
+  embed_phase.dst_subfolder_spec = "16"
+  embed_phase.dst_path = "$(CONTENTS_FOLDER_PATH)/Watch"
+end
+
+product_ref = watch.product_reference
+unless embed_phase.files_references.include?(product_ref)
+  build_file = embed_phase.add_file_reference(product_ref, true)
+  build_file.settings = { "ATTRIBUTES" => ["RemoveHeadersOnCopy"] }
+end
+
+# The iOS app must build the watch app first (so it can embed it).
+app.add_dependency(watch) unless app.dependencies.any? { |d| d.target == watch }
+
+# ---------------------------------------------------------------------------
+# 5. Dedicated shared scheme so the watch app is discoverable for xcodebuild.
+# ---------------------------------------------------------------------------
+scheme_path = File.join(
+  PROJECT_PATH, "xcshareddata", "xcschemes", "#{WATCH_TARGET}.xcscheme"
+)
+unless File.exist?(scheme_path)
+  scheme = Xcodeproj::XCScheme.new
+  scheme.add_build_target(watch)
+  scheme.set_launch_target(watch)
+  scheme.save_as(PROJECT_PATH, WATCH_TARGET, true)
+end
+
+project.save
+
+if created
+  puts "Created #{WATCH_TARGET} watchOS app target, wired sources/shared files, embedded it in #{APP_TARGET}, and added a shared scheme."
+else
+  puts "#{WATCH_TARGET} already existed — refreshed sources, shared-file membership, embedding, and scheme (no duplicates)."
+end


### PR DESCRIPTION
## Summary

A single-screen, **tap-only** watchOS app whose one job is the fastest possible log of a *resisted* temptation from the wrist — the wrist-native twin of the Home Screen quick-log widget. Closes the build stage of #49.

Tap the large habit-color circle → one resisted `TemptationEvent` is written via the shared `TemptationLogger.logResisted`, a `.success` Taptic fires, and a 1.2s "Logged" acknowledgment shows. The screen also displays the resolved target habit's name and today's resisted count.

## Key architectural decision: CloudKit sync, not App Groups

App Groups do **not** bridge iPhone↔Apple Watch (separate devices), so the watch can't use the widget's shared App-Group store. The watch has its **own** SwiftData `ModelContainer` pointed at the same CloudKit container (`.private("iCloud.com.resistor.app")`) — phone/watch parity comes from CloudKit sync. Logging writes locally immediately and never waits on phone reachability.

## What's included

- **`ResistorWatch/`** — `@main` app, `WatchLogView` (6 states: loggable / in-flight / success / no-habit / habit-unavailable / count-unavailable, ~800ms debounce, Reduce-Motion alternative, accessibility), `WatchLogStore` (`@Observable` provider: deterministic `defaultHabitId` → first-non-archived target resolution, resisted-today count matching `Habit.todayEventsCount`), `WatchModelContainer`, Info.plist (`WKApplication`/`WKCompanionAppBundleIdentifier`), entitlements (CloudKit, no app group).
- **`scripts/add_watch_target.rb`** — idempotent target wiring (embeds the watch app into the iOS app, reuses the shared model/util files rather than duplicating, dedicated `ResistorWatch` scheme). Bundle id `com.resistor.app.watchkitapp`.
- **`ResistorTests/WatchLogStoreLogicTests.swift`** — 15 tests mirroring the watch logic against the shared models (the watch target's `WatchLogStore` isn't importable from the iOS test target — same pattern as `QuickLogWidgetTests`).
- **`docs/design.md`** — Flow 6, UC-WATCH-1…6, full interaction/visual spec.
- **`CLAUDE.md`** — watchOS runtime requirement for the iOS test action + watch app overview.

## Test plan

- `xcodebuild -scheme ResistorWatch -destination 'generic/platform=watchOS Simulator' build` → **BUILD SUCCEEDED**
- `xcodebuild -scheme Resistor -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` → **BUILD SUCCEEDED** (Embed Watch Content phase validates)
- `ResistorTests`: **248/248 pass** (233 pre-existing + 15 new); `DataExporterTests` green.
- Device-only (not verifiable in sim): cross-device CloudKit propagation and the real Taptic haptic.

## ⚠️ Requires watchOS simulator runtime

The `Resistor` scheme now embeds the watch app, so `xcodebuild test -scheme Resistor` builds it and **fails without the watchOS simulator runtime**. Install once: `xcodebuild -downloadPlatform watchOS` (~4 GB). Documented in CLAUDE.md.

## Manual steps still required (portal/Xcode, same as widget #47)

1. Register `com.resistor.app.watchkitapp` as a paired-watch app of `com.resistor.app` in the Developer portal.
2. Enable the CloudKit capability for `iCloud.com.resistor.app` on the `ResistorWatch` target.
3. Let automatic signing (team `HBXLU45HR7`) provision the watch target.

## Notes

- One spec deviation: `UIAccessibility.post(.announcement,…)` is unavailable on watchOS and was dropped; VoiceOver still reads the button label / "Logged" element.
- Outstanding (can't be done with the iPhone screenshot harness): on-watch visual tuning at 41/45/49mm and glyph contrast across habit hues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)