### PR TITLE
Add first-run onboarding intro explaining Resistor's premise

### DIFF
--- a/Resistor.xcodeproj/project.pbxproj
+++ b/Resistor.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		B2000007000000000000001A /* OnboardingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000007000000000000000A /* OnboardingViewModelTests.swift */; };
 		B2000008000000000000001A /* HabitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000008000000000000000A /* HabitTests.swift */; };
 		B2000009000000000000001A /* UserSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000009000000000000000A /* UserSettingsTests.swift */; };
+		B20000FF000000000000001A /* OnboardingGatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20000FF000000000000000A /* OnboardingGatingTests.swift */; };
 		B200000A000000000000001A /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000A000000000000000A /* IntegrationTests.swift */; };
 		B200000B000000000000001A /* InsightsViewModelPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000B000000000000000A /* InsightsViewModelPerformanceTests.swift */; };
 		B200000C000000000000001A /* TipJarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000C000000000000000A /* TipJarViewModelTests.swift */; };
@@ -186,6 +187,7 @@
 		B2000007000000000000000A /* OnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		B2000008000000000000000A /* HabitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HabitTests.swift; sourceTree = "<group>"; };
 		B2000009000000000000000A /* UserSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsTests.swift; sourceTree = "<group>"; };
+		B20000FF000000000000000A /* OnboardingGatingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingGatingTests.swift; sourceTree = "<group>"; };
 		B200000A000000000000000A /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
 		B200000B000000000000000A /* InsightsViewModelPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModelPerformanceTests.swift; sourceTree = "<group>"; };
 		B200000C000000000000000A /* TipJarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipJarViewModelTests.swift; sourceTree = "<group>"; };
@@ -426,6 +428,7 @@
 				B2000007000000000000000A /* OnboardingViewModelTests.swift */,
 				B2000008000000000000000A /* HabitTests.swift */,
 				B2000009000000000000000A /* UserSettingsTests.swift */,
+				B20000FF000000000000000A /* OnboardingGatingTests.swift */,
 				B200000A000000000000000A /* IntegrationTests.swift */,
 				B200000B000000000000000A /* InsightsViewModelPerformanceTests.swift */,
 				B200000C000000000000000A /* TipJarViewModelTests.swift */,
@@ -684,6 +687,7 @@
 				B2000007000000000000001A /* OnboardingViewModelTests.swift in Sources */,
 				B2000008000000000000001A /* HabitTests.swift in Sources */,
 				B2000009000000000000001A /* UserSettingsTests.swift in Sources */,
+				B20000FF000000000000001A /* OnboardingGatingTests.swift in Sources */,
 				B200000A000000000000001A /* IntegrationTests.swift in Sources */,
 				B200000B000000000000001A /* InsightsViewModelPerformanceTests.swift in Sources */,
 				B200000C000000000000001A /* TipJarViewModelTests.swift in Sources */,

--- a/Resistor/Services/UITestSeed.swift
+++ b/Resistor/Services/UITestSeed.swift
@@ -17,6 +17,13 @@ enum UITestSeed {
         ProcessInfo.processInfo.arguments.contains("-uiTestMode")
     }
 
+    /// True when the run should render the first-run onboarding flow instead of
+    /// the seeded main app. Boots an empty in-memory store with onboarding
+    /// incomplete (and a nil accent color, matching a genuine first run).
+    static var isOnboarding: Bool {
+        isActive && ProcessInfo.processInfo.arguments.contains("-uiTestOnboarding")
+    }
+
     /// Color scheme to force during a screenshot run. `.dark` when launched with
     /// `-uiTestDarkMode` (so dark-mode captures are deterministic), otherwise
     /// `nil` — which means "follow the system" and leaves normal runs untouched.
@@ -29,6 +36,11 @@ enum UITestSeed {
     /// relative shape of the data (today / this week / earlier) stable while
     /// still landing in the current calendar period.
     static func populate(_ context: ModelContext) {
+        // First-run onboarding capture: leave the store empty and onboarding
+        // incomplete so ContentView routes to OnboardingView with a nil accent
+        // (system blue tint), exactly as a genuine first launch.
+        if isOnboarding { return }
+
         let calendar = Calendar.current
         let now = Date()
 

--- a/Resistor/Views/OnboardingView.swift
+++ b/Resistor/Views/OnboardingView.swift
@@ -3,162 +3,253 @@ import SwiftData
 
 struct OnboardingView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var viewModel: OnboardingViewModel?
+    @State private var step: OnboardingStep = .intro
     var onComplete: () -> Void
+
+    private enum OnboardingStep {
+        case intro
+        case firstHabit
+    }
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 32) {
-                // Header
-                VStack(spacing: 16) {
-                    Image(systemName: "bolt.shield.fill")
-                        .font(.system(size: 72))
-                        .foregroundStyle(.blue)
-
-                    Text("Resistor")
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
-
-                    Text("Track your temptations, understand your patterns.")
-                        .font(.body)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.horizontal)
-                }
-                .padding(.top, 40)
-
-                Spacer()
-
-                // Form
-                if let vm = viewModel {
-                    VStack(spacing: 20) {
-                        Text("What habit are you working on?")
-                            .font(.headline)
-
-                        TextField("e.g., Sugar, Smoking, Social Media", text: Binding(
-                            get: { vm.habitName },
-                            set: { vm.habitName = $0 }
-                        ))
-                        .textFieldStyle(.roundedBorder)
-                        .padding(.horizontal)
-
-                        TextField("Description (optional)", text: Binding(
-                            get: { vm.habitDescription },
-                            set: { vm.habitDescription = $0 }
-                        ))
-                        .textFieldStyle(.roundedBorder)
-                        .padding(.horizontal)
-
-                        // Color picker
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Color")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                                .padding(.horizontal)
-
-                            ScrollView(.horizontal, showsIndicators: false) {
-                                HStack(spacing: 12) {
-                                    ForEach(HabitsViewModel.availableColors, id: \.hex) { color in
-                                        Circle()
-                                            .fill(Color(hex: color.hex) ?? .blue)
-                                            .frame(width: 36, height: 36)
-                                            .overlay(
-                                                Circle()
-                                                    .stroke(Color.primary, lineWidth: vm.selectedColorHex == color.hex ? 3 : 0)
-                                            )
-                                            .onTapGesture {
-                                                vm.selectedColorHex = color.hex
-                                            }
-                                            .accessibilityLabel(color.name)
-                                            .accessibilityAddTraits(vm.selectedColorHex == color.hex ? [.isButton, .isSelected] : .isButton)
-                                    }
-                                }
-                                .padding(.horizontal)
-                                // Vertical room so the selection ring isn't
-                                // clipped by the scroll view's content bounds.
-                                .padding(.vertical, 4)
-                            }
-                        }
-
-                        // Icon picker
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Icon")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                                .padding(.horizontal)
-
-                            ScrollView(.horizontal, showsIndicators: false) {
-                                HStack(spacing: 12) {
-                                    ForEach(HabitsViewModel.availableIcons, id: \.self) { icon in
-                                        Image(systemName: icon)
-                                            .font(.title2)
-                                            .frame(width: 44, height: 44)
-                                            .background(
-                                                RoundedRectangle(cornerRadius: 8)
-                                                    .fill(vm.selectedIconName == icon ? Color.blue.opacity(0.2) : Color.clear)
-                                            )
-                                            .overlay(
-                                                RoundedRectangle(cornerRadius: 8)
-                                                    .stroke(vm.selectedIconName == icon ? Color.blue : Color.clear, lineWidth: 2)
-                                            )
-                                            .onTapGesture {
-                                                vm.selectedIconName = icon
-                                            }
-                                            .accessibilityLabel(icon.replacingOccurrences(of: ".fill", with: "").replacingOccurrences(of: ".", with: " "))
-                                            .accessibilityAddTraits(vm.selectedIconName == icon ? [.isButton, .isSelected] : .isButton)
-                                    }
-                                }
-                                .padding(.horizontal)
-                                // Vertical room so the selection border isn't
-                                // clipped by the scroll view's content bounds.
-                                .padding(.vertical, 4)
-                            }
-                        }
-                    }
-                }
-
-                Spacer()
-
-                // Actions
-                if let vm = viewModel {
-                    VStack(spacing: 12) {
-                        Button(action: {
-                            if vm.createFirstHabit() {
-                                onComplete()
-                            }
-                        }) {
-                            Text("Create habit and start logging")
-
-                                .font(.headline)
-                                .foregroundStyle(.white)
-                                .frame(maxWidth: .infinity)
-                                .padding()
-                                .background(vm.canCreateHabit ? Color.blue : Color.gray)
-                                .cornerRadius(12)
-                        }
-                        .disabled(!vm.canCreateHabit)
-                        .accessibilityHint(vm.canCreateHabit ? "" : "Enter a habit name first")
-
-                        Button(action: {
-                            if vm.skipOnboarding() {
-                                onComplete()
-                            }
-                        }) {
-                            Text("Skip for now")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                        }
-                        .accessibilityHint("You can add habits later from the Habits tab")
-                    }
-                    .padding(.horizontal)
-                    .padding(.bottom, 32)
+            Group {
+                switch step {
+                case .intro:
+                    introStep
+                        .transition(reduceMotion
+                            ? .opacity
+                            : .move(edge: .trailing).combined(with: .opacity))
+                case .firstHabit:
+                    firstHabitStep
+                        .transition(reduceMotion
+                            ? .opacity
+                            : .move(edge: .trailing).combined(with: .opacity))
                 }
             }
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: step)
         }
         .onAppear {
             if viewModel == nil {
                 viewModel = OnboardingViewModel(modelContext: modelContext)
+            }
+        }
+    }
+
+    // MARK: - Intro Step
+
+    private var introStep: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                Spacer(minLength: 0)
+
+                // Identity block
+                VStack(spacing: 16) {
+                    Image(systemName: "bolt.shield.fill")
+                        .font(.system(size: 64))
+                        .foregroundStyle(.tint)
+                        .accessibilityHidden(true)
+
+                    Text("Resistor")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .foregroundStyle(Color.primary)
+                }
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+
+                Spacer().frame(height: 40)
+
+                // Premise block
+                VStack(alignment: .leading, spacing: 20) {
+                    Text("Log each moment a temptation hits, and whether you resisted or gave in.")
+                        .foregroundStyle(Color.primary)
+
+                    Text("Over time, Resistor shows you the patterns: when temptations cluster and how often you resist.")
+                        .foregroundStyle(Color.primary)
+
+                    Text("No streaks, no scores, no reminders.")
+                        .foregroundStyle(Color(.secondaryLabel))
+                }
+                .font(.body)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityElement(children: .combine)
+
+                Spacer(minLength: 0)
+
+                // Forward control
+                Button(action: {
+                    step = .firstHabit
+                }) {
+                    Text("Continue")
+                        .font(.title2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 20)
+                        .background(Color.accentColor)
+                        .cornerRadius(16)
+                }
+                .padding(.bottom, 32)
+            }
+            .padding(.horizontal, 24)
+            .frame(maxWidth: .infinity, minHeight: introMinHeight)
+        }
+    }
+
+    private var introMinHeight: CGFloat {
+        // Allow the centered layout to fill the viewport at default sizes while
+        // letting the ScrollView grow past it at the largest Dynamic Type sizes.
+        #if canImport(UIKit)
+        return UIScreen.main.bounds.height - 100
+        #else
+        return 600
+        #endif
+    }
+
+    // MARK: - First Habit Step
+
+    private var firstHabitStep: some View {
+        VStack(spacing: 32) {
+            // Header
+            VStack(spacing: 16) {
+                Image(systemName: "bolt.shield.fill")
+                    .font(.system(size: 72))
+                    .foregroundStyle(.blue)
+
+                Text("Resistor")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+            }
+            .padding(.top, 40)
+
+            Spacer()
+
+            // Form
+            if let vm = viewModel {
+                VStack(spacing: 20) {
+                    Text("What habit are you working on?")
+                        .font(.headline)
+
+                    TextField("e.g., Sugar, Smoking, Social Media", text: Binding(
+                        get: { vm.habitName },
+                        set: { vm.habitName = $0 }
+                    ))
+                    .textFieldStyle(.roundedBorder)
+                    .padding(.horizontal)
+
+                    TextField("Description (optional)", text: Binding(
+                        get: { vm.habitDescription },
+                        set: { vm.habitDescription = $0 }
+                    ))
+                    .textFieldStyle(.roundedBorder)
+                    .padding(.horizontal)
+
+                    // Color picker
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Color")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal)
+
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 12) {
+                                ForEach(HabitsViewModel.availableColors, id: \.hex) { color in
+                                    Circle()
+                                        .fill(Color(hex: color.hex) ?? .blue)
+                                        .frame(width: 36, height: 36)
+                                        .overlay(
+                                            Circle()
+                                                .stroke(Color.primary, lineWidth: vm.selectedColorHex == color.hex ? 3 : 0)
+                                        )
+                                        .onTapGesture {
+                                            vm.selectedColorHex = color.hex
+                                        }
+                                        .accessibilityLabel(color.name)
+                                        .accessibilityAddTraits(vm.selectedColorHex == color.hex ? [.isButton, .isSelected] : .isButton)
+                                }
+                            }
+                            .padding(.horizontal)
+                            // Vertical room so the selection ring isn't
+                            // clipped by the scroll view's content bounds.
+                            .padding(.vertical, 4)
+                        }
+                    }
+
+                    // Icon picker
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Icon")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal)
+
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 12) {
+                                ForEach(HabitsViewModel.availableIcons, id: \.self) { icon in
+                                    Image(systemName: icon)
+                                        .font(.title2)
+                                        .frame(width: 44, height: 44)
+                                        .background(
+                                            RoundedRectangle(cornerRadius: 8)
+                                                .fill(vm.selectedIconName == icon ? Color.blue.opacity(0.2) : Color.clear)
+                                        )
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: 8)
+                                                .stroke(vm.selectedIconName == icon ? Color.blue : Color.clear, lineWidth: 2)
+                                        )
+                                        .onTapGesture {
+                                            vm.selectedIconName = icon
+                                        }
+                                        .accessibilityLabel(icon.replacingOccurrences(of: ".fill", with: "").replacingOccurrences(of: ".", with: " "))
+                                        .accessibilityAddTraits(vm.selectedIconName == icon ? [.isButton, .isSelected] : .isButton)
+                                }
+                            }
+                            .padding(.horizontal)
+                            // Vertical room so the selection border isn't
+                            // clipped by the scroll view's content bounds.
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+            }
+
+            Spacer()
+
+            // Actions
+            if let vm = viewModel {
+                VStack(spacing: 12) {
+                    Button(action: {
+                        if vm.createFirstHabit() {
+                            onComplete()
+                        }
+                    }) {
+                        Text("Create habit and start logging")
+
+                            .font(.headline)
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(vm.canCreateHabit ? Color.blue : Color.gray)
+                            .cornerRadius(12)
+                    }
+                    .disabled(!vm.canCreateHabit)
+                    .accessibilityHint(vm.canCreateHabit ? "" : "Enter a habit name first")
+
+                    Button(action: {
+                        if vm.skipOnboarding() {
+                            onComplete()
+                        }
+                    }) {
+                        Text("Skip for now")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityHint("You can add habits later from the Habits tab")
+                }
+                .padding(.horizontal)
+                .padding(.bottom, 32)
             }
         }
     }

--- a/ResistorTests/OnboardingGatingTests.swift
+++ b/ResistorTests/OnboardingGatingTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+import SwiftData
+@testable import Resistor
+
+/// Runtime verification of the onboarding gate (issue #52, UC-OB2 / UC-OB3).
+///
+/// The intro step itself is a view-only change with no ViewModel logic, so the
+/// string/ordering assertions are source-verified. What *is* runtime-testable is
+/// the gating contract the two-step flow depends on and must not break:
+/// onboarding shows first-run only, completing OR skipping clears the gate, and
+/// Delete All Data restores it. These tests reproduce ContentView's
+/// `needsOnboarding` predicate against real SwiftData state.
+@MainActor
+final class OnboardingGatingTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUp() async throws {
+        container = try TestHelpers.makeModelContainer()
+        context = container.mainContext
+    }
+
+    override func tearDown() async throws {
+        container = nil
+        context = nil
+    }
+
+    /// Mirrors `ContentView.needsOnboarding` exactly: no settings -> show;
+    /// otherwise gate on `hasCompletedOnboarding`.
+    private func needsOnboarding() throws -> Bool {
+        let settings = try context.fetch(FetchDescriptor<UserSettings>()).first
+        guard let settings else { return true }
+        return !settings.hasCompletedOnboarding
+    }
+
+    // MARK: - UC-OB3: first-run only
+
+    func testFirstRunWithNoSettingsShowsOnboarding() throws {
+        XCTAssertTrue(try needsOnboarding())
+    }
+
+    func testFreshSettingsDefaultShowsOnboarding() throws {
+        // A freshly inserted UserSettings (e.g. via initializeSettingsIfNeeded)
+        // defaults hasCompletedOnboarding = false, so the gate is still open.
+        context.insert(UserSettings())
+        try context.save()
+        XCTAssertTrue(try needsOnboarding())
+    }
+
+    // MARK: - UC-OB2: completing the first-habit step clears the gate
+
+    func testCompletingFirstHabitStepClearsGate() throws {
+        let vm = OnboardingViewModel(modelContext: context)
+        vm.habitName = "Smoking"
+
+        XCTAssertTrue(vm.createFirstHabit())
+        XCTAssertFalse(try needsOnboarding(),
+                       "Onboarding must not reappear after creating the first habit")
+    }
+
+    // MARK: - UC-OB2: skipping the first-habit step also clears the gate
+
+    func testSkippingFirstHabitStepClearsGate() throws {
+        let vm = OnboardingViewModel(modelContext: context)
+
+        XCTAssertTrue(vm.skipOnboarding())
+        XCTAssertFalse(try needsOnboarding(),
+                       "Onboarding must not reappear after skipping")
+    }
+
+    // MARK: - UC-OB3: never reappears in-app once completed
+
+    func testGateStaysClosedAcrossReReads() throws {
+        let vm = OnboardingViewModel(modelContext: context)
+        vm.habitName = "Sugar"
+        _ = vm.createFirstHabit()
+
+        // Multiple reads simulate the app re-evaluating needsOnboarding on
+        // every body render — it must remain false with no re-open path.
+        XCTAssertFalse(try needsOnboarding())
+        XCTAssertFalse(try needsOnboarding())
+    }
+
+    // MARK: - UC-OB3: reappears only after Delete All Data
+
+    func testDeleteAllDataReopensGate() throws {
+        // Complete onboarding first.
+        let vm = OnboardingViewModel(modelContext: context)
+        vm.habitName = "Smoking"
+        _ = vm.createFirstHabit()
+        XCTAssertFalse(try needsOnboarding())
+
+        // Reproduce HabitsView.deleteAllData(): wipe everything, then insert a
+        // fresh default UserSettings (hasCompletedOnboarding == false).
+        // (ContextTag is omitted here only because the shared test ModelContainer
+        // schema doesn't register it; the gate-reopen behavior depends on the
+        // UserSettings reset, which is fully exercised below.)
+        try context.delete(model: TemptationEvent.self)
+        try context.delete(model: Habit.self)
+        try context.delete(model: UserSettings.self)
+        context.insert(UserSettings())
+        try context.save()
+
+        XCTAssertTrue(try needsOnboarding(),
+                      "Onboarding must reappear after Delete All Data")
+
+        // And the wipe actually removed the seeded habit.
+        let habits = try context.fetch(FetchDescriptor<Habit>())
+        XCTAssertTrue(habits.isEmpty)
+    }
+}

--- a/ResistorUITests/SnapshotTests.swift
+++ b/ResistorUITests/SnapshotTests.swift
@@ -28,6 +28,42 @@ final class SnapshotTests: XCTestCase {
         captureAllScreens(dark: true)
     }
 
+    /// First-run onboarding intro capture → `00-Onboarding.png` /
+    /// `00-Onboarding-dark.png`. Launches with `-uiTestOnboarding`, which boots
+    /// an empty store with onboarding incomplete and a nil accent (system blue),
+    /// so ContentView routes to the new intro premise screen.
+    func testCaptureOnboardingIntro() {
+        let app = XCUIApplication()
+        app.launchArguments += ["-uiTestMode", "-uiTestOnboarding"]
+        app.launch()
+        _ = app.staticTexts["Resistor"].waitForExistence(timeout: 5)
+        snapshot(app, name: "00-Onboarding")
+    }
+
+    func testCaptureOnboardingIntroDark() {
+        let app = XCUIApplication()
+        app.launchArguments += ["-uiTestMode", "-uiTestOnboarding", "-uiTestDarkMode"]
+        app.launch()
+        _ = app.staticTexts["Resistor"].waitForExistence(timeout: 5)
+        snapshot(app, name: "00-Onboarding-dark")
+    }
+
+    /// Onboarding intro at an accessibility (XXXL) Dynamic Type size, to verify
+    /// the premise text and Continue button reflow/scroll rather than clip.
+    func testCaptureOnboardingIntroLargeText() {
+        let app = XCUIApplication()
+        app.launchArguments += ["-uiTestMode", "-uiTestOnboarding"]
+        app.launchArguments += ["-UIPreferredContentSizeCategoryName", "UICTContentSizeCategoryAccessibilityXXXL"]
+        app.launch()
+        _ = app.staticTexts["Resistor"].waitForExistence(timeout: 5)
+        snapshot(app, name: "00-Onboarding-large")
+        // Scroll to the bottom to confirm the Continue button is reachable and
+        // not clipped at the largest Dynamic Type size.
+        app.swipeUp(velocity: .slow)
+        app.swipeUp(velocity: .slow)
+        snapshot(app, name: "00-Onboarding-large-b")
+    }
+
     /// Walks every screen and captures a named screenshot of each. When `dark`
     /// is true the app is launched in forced dark mode and each screenshot name
     /// gets a `-dark` suffix so light and dark captures coexist on disk.

--- a/docs/design.md
+++ b/docs/design.md
@@ -48,6 +48,46 @@ Comprehensive design document for Resistor, an iOS habit-tracking app that logs 
 
 ## User Flows
 
+### Flow 0: First-Run Onboarding (premise intro → first habit)
+
+First launch only. Today the onboarding screen (S0) drops the user straight into
+naming a first habit, fronted only by a one-line tagline. A first-run user who has
+never seen a temptation-logging tool has no model for *what they are about to do* or
+*why the app deliberately omits streaks, scores, and reminders* — so the very design
+choices that make Resistor trustworthy (no gamification, no nudges, no judgment) read
+as missing features instead of intentional ones. This flow adds a brief premise
+**intro step before** the existing first-habit step to set that frame, then hands off
+to habit creation unchanged.
+
+The intro is **explanatory only**. It collects no input, makes no promises, and uses no
+motivational copy. It states what the app records and what it does not do, then steps
+aside.
+
+1. App launches for the first time (`UserSettings.hasCompletedOnboarding == false`).
+2. **Intro step** presents the premise: the user logs moments of temptation (and
+   whether they resisted or gave in), and the app turns that into pattern visibility —
+   not streaks, scores, or reminders. The user advances with a forward control.
+3. Flow continues into the **existing first-habit step** (name, optional description,
+   icon/color) — unchanged (S0 as it stands today).
+4. The user either creates a first habit ("Create habit and start logging") or skips
+   ("Skip for now"); both set `hasCompletedOnboarding = true` and land on the Log tab,
+   exactly as today.
+
+Edge cases:
+- **Skipping is still possible from the first-habit step**, as today. The intro step
+  itself is informational and is simply advanced past; reaching the habit step is not a
+  commitment to create a habit.
+- **The intro is first-run only.** It never reappears on later launches and there is no
+  in-app entry point to re-open it. Re-running onboarding only happens after "Delete All
+  Data" resets to first-run state (existing behavior), at which point the intro shows
+  again as part of the fresh first run.
+- **Back navigation** from the first-habit step to the intro step is permitted within the
+  onboarding flow (it is a self-contained first-run flow, not the tab-bar navigation the
+  one-level-deep rule governs). Advancing forward never loses entered habit data.
+- This flow adds **no persisted state and no schema change** — it is a presentational
+  step gated by the same `hasCompletedOnboarding` flag that already gates onboarding.
+  CloudKit-safe by construction.
+
 ### Flow 1: Quick Log (Core Loop)
 
 1. User opens app, lands on Log screen.
@@ -318,12 +358,205 @@ Edge cases:
 
 ### S0: Onboarding (first-run only)
 
-- App explanation (one or two sentences)
+The onboarding flow now has **two steps**: a premise **intro step** followed by the
+existing **first-habit step**. See Flow 0.
+
+**Step 1 — Premise intro (new):**
+
+- App name and identity mark
+- A short explanation of the core premise: log moments of temptation and whether they
+  were resisted or given in to; the app surfaces patterns over time
+- An explicit statement of what the app deliberately does *not* do: no streaks, no
+  scores, no reminders, no judgment
+- A forward control to continue to the first-habit step
+
+**Step 2 — First habit (existing, unchanged):**
+
 - Text field for first habit name
 - Optional description
 - Icon/color picker
 - "Create habit and start logging" button
 - "Skip for now" option
+
+#### Onboarding Intro (component and state spec)
+
+This is the build-ready spec for Step 1. Step 2 is untouched.
+
+**Step mechanism (how Step 1 relates to Step 2).**
+
+`OnboardingView` keeps its single `NavigationStack` root and gains a step enum driving
+which content the stack shows:
+
+```swift
+private enum OnboardingStep { case intro, firstHabit }
+@State private var step: OnboardingStep = .intro
+```
+
+- **Not** a `TabView(.page)` and **not** a `NavigationLink` push. A paged `TabView` would
+  add swipe-between-steps gesture ambiguity and dot indicators we do not want; a push
+  would add a back chevron and large-title chrome that fights the centered intro. Instead
+  the stack's content switches on `step` with an explicit, animated transition (below).
+  This keeps the existing `onComplete` closure and the existing first-habit view body
+  exactly as they are — the first-habit content moves verbatim into the `.firstHabit`
+  branch.
+- The intro **collects no input** and writes **nothing** to the model. `Continue` only
+  sets `step = .firstHabit`. `hasCompletedOnboarding` is still set solely by the existing
+  `createFirstHabit()` / `skipOnboarding()` paths in `OnboardingViewModel` — no VM change
+  is required. (The `OnboardingViewModel` may still init lazily in `onAppear` as today; it
+  is unused on the intro step.)
+- **Back navigation** (Step 2 → Step 1) is permitted per Flow 0 but **optional** and
+  low-priority: if added, it is a leading `Button("Back")` (plain, `.secondary`) in the
+  first-habit step's action area that sets `step = .intro` with the reverse transition.
+  Entered habit name/description/color/icon live on the persistent `OnboardingViewModel`,
+  so going back and forward never loses them. The intro itself has no back affordance (it
+  is the first thing shown; there is nowhere behind it).
+
+**Intro layout (top → bottom), inside `ScrollView { VStack }`:**
+
+The whole intro is wrapped in a `ScrollView` so it can grow past the viewport at the
+largest Dynamic Type sizes instead of clipping (see Accessibility). At default sizes the
+content does not fill the screen, so the `VStack` is vertically centered via a
+`.frame(minHeight:)` equal to the scroll viewport plus top/bottom `Spacer()`s inside, or
+equivalently `frame(maxHeight: .infinity)` with leading/trailing spacers — implementer's
+choice, the visual target is: identity block optically centered in the upper-middle,
+premise block beneath it, `Continue` pinned to the bottom safe-area inset.
+
+- **Screen padding:** 24pt horizontal (the standard Screen-padding token), applied to the
+  text column. `Continue` is also inset 24pt horizontally.
+- **Identity block** — `VStack(spacing: 16)`, `.multilineTextAlignment(.center)`:
+  - Identity mark: `Image(systemName: "bolt.shield.fill")`, `.font(.system(size: 64))`,
+    `.foregroundStyle(.tint)` (resolves the user accent at the app root; on first run the
+    accent is system default, so this is the muted/system tint, never a hardcoded brand
+    color). Reuses the existing onboarding mark, sized down from 72 → 64 to leave room for
+    the premise block. `.accessibilityHidden(true)` (decorative; the name carries identity).
+  - App name: `Text("Resistor")`, `.font(.largeTitle).fontWeight(.bold)`,
+    `Color.primary`.
+- **Spacer / gap:** 40pt fixed gap (`Spacer().frame(height: 40)` or
+  `.padding(.top, 40)` on the premise block) between identity and premise blocks — large
+  enough that the premise reads as a distinct section, not a subtitle of the title. This
+  replaces the old single-line tagline, which is removed.
+- **Premise block** — `VStack(alignment: .leading, spacing: 20)`, **leading-aligned**
+  (left-aligned reads as clinical fact statements; centered multi-line body wraps read as
+  marketing). Each of the three premise lines is its own `Text`:
+  - Line 1: `Text("Log each moment a temptation hits, and whether you resisted or gave in.")`
+  - Line 2: `Text("Over time, Resistor shows you the patterns: when temptations cluster and how often you resist.")`
+  - Line 3 (omissions): `Text("No streaks, no scores, no reminders.")`
+  - All three: `.font(.body)`, `.fixedSize(horizontal: false, vertical: true)` (so they
+    wrap and never truncate). Lines 1 and 2 are `Color.primary`; **line 3 is
+    `Color(.secondaryLabel)`** to read as a quieter factual footnote, visually
+    subordinate to what the app *does* (lines 1–2) — this also reinforces that line 3 is
+    a product fact, not a headline. The 20pt inter-line spacing groups them as three peers.
+  - No leading bullets, no icons, no numbering — plain stacked sentences. (Decorative
+    SF Symbol bullets were considered and rejected: they imply a checklist/feature-grid
+    and add VoiceOver noise.)
+- **Forward control** — pinned to bottom:
+  - `Text("Continue")`, `.font(.title2).fontWeight(.semibold)`, white text, full-width,
+    `.padding(.vertical, 20)`, background `Color.accentColor` (the resolved app tint),
+    `.cornerRadius(16)`. This is the **Primary Button** from the component catalog,
+    identical in treatment to "Log Temptation" and to the first-habit step's primary
+    button, so the forward action is visually consistent across both onboarding steps.
+  - Always enabled (no input gate). `.padding(.bottom, 32)` above the home indicator,
+    matching the first-habit step's bottom inset.
+
+**States.**
+
+- **Default (and only populated state):** identity block + three premise lines +
+  enabled `Continue`, as above. There is no data to load, so no loading/empty/error
+  state — the intro is static text. There is no selected/disabled state (no inputs;
+  `Continue` is never disabled).
+- **Pressed:** `Continue` uses the system button press dimming (no custom highlight
+  needed). On activate it advances to the first-habit step.
+- **Transition to Step 2:** content swaps via `.transition`. With motion allowed, an
+  asymmetric slide+fade: intro slides leading-out / first-habit slides trailing-in
+  (`.move(edge: .trailing).combined(with: .opacity)`), `.animation(.easeInOut(duration:
+  0.3), value: step)`. Back-nav (if implemented) uses the reverse.
+- **Reduce Motion variant:** when `reduceMotion` is true, the transition is a plain
+  `.opacity` cross-fade (or no animation at all — implementer may set
+  `.animation(nil, value: step)`). No slide, no scale. The intro requires no motion to
+  function; the transition is purely decorative and fully gated on `reduceMotion`.
+
+**Color and accent.** The intro uses only semantic colors (`Color.primary`,
+`Color(.secondaryLabel)`, `Color(.systemBackground)`) plus the resolved app `.tint` /
+`Color.accentColor` for the mark and the primary button — so dark mode is automatic and
+correct. No habit color appears on the intro (no habit exists yet on the intro step). No
+hardcoded brand hex. On first run `accentColorHex` is nil, so `.tint` is the system
+default; the intro must not assume any specific accent.
+
+#### Onboarding Intro (use cases)
+
+The intro exists to give a first-run user a correct mental model **before** their first
+action, so the absence of streaks/scores/reminders reads as intentional rather than
+incomplete. It requires **no schema change** and persists nothing new — it is gated by
+the existing `UserSettings.hasCompletedOnboarding` flag (Flow 0).
+
+**UC-OB1 — First-run user sees the premise before creating a habit.**
+As a first-run user, I want a short explanation of what Resistor records and how it
+differs from a streak tracker so that I understand what I'm about to do before I do it.
+Acceptance criteria:
+- On first launch (`hasCompletedOnboarding == false`), the premise intro step is shown
+  **before** the first-habit step.
+- The intro states, in clinical language, that the user logs moments of temptation and
+  whether they resisted or gave in, and that the app shows patterns over time.
+- The intro explicitly states the app does **not** use streaks, scores, or reminders.
+- The intro collects no input and makes no claim about outcomes the user will achieve.
+- A forward control advances to the first-habit step.
+
+**UC-OB2 — The intro never blocks reaching the existing flow.**
+As a first-run user, I want to move past the intro quickly so that it is a frame, not a
+gate.
+Acceptance criteria:
+- The intro step is advanced past with a single forward action; it requires no data
+  entry.
+- After advancing, the first-habit step is reached exactly as it exists today, with
+  "Create habit and start logging" and "Skip for now" both available.
+- Completing or skipping the first-habit step sets `hasCompletedOnboarding = true` and
+  lands on the Log tab (unchanged behavior).
+
+**UC-OB3 — The intro is first-run only and re-runs only on data reset.**
+As a returning user, I want never to see the intro again so that it does not become a
+recurring interruption (the app has no reminders or nudges by design).
+Acceptance criteria:
+- On every launch after onboarding completes, the intro is not shown.
+- There is no in-app control that re-opens the intro.
+- After "Delete All Data" resets the app to first-run state, the intro shows again as
+  part of the fresh first run.
+
+#### Onboarding Intro (exact copy)
+
+All strings clinical, no motivational/emotional language, no emoji, honoring the
+Forbidden Language table. These are the **final strings** the implementer ships; the
+ux-designer owns their on-screen placement and grouping (single intro screen vs. two),
+not their wording.
+
+The intro fits on **one screen**. Scope keeps it to a single screen (see Scope below);
+the copy is written so a designer can lay it out as one screen without a second.
+
+| Element | Final string |
+|---------|--------------|
+| App name | `Resistor` |
+| Premise line 1 | `Log each moment a temptation hits, and whether you resisted or gave in.` |
+| Premise line 2 | `Over time, Resistor shows you the patterns: when temptations cluster and how often you resist.` |
+| What it omits (line 3) | `No streaks, no scores, no reminders.` |
+| Forward control | `Continue` |
+
+Copy notes:
+- The three premise lines map to the three things the intro must convey: (1) **what you
+  record** — the moment and the outcome; (2) **what you get back** — pattern visibility;
+  (3) **what it deliberately is not** — no streaks/scores/reminders. A designer may
+  render these as three short lines or fold (1)+(2) into a tight pair, but all three
+  ideas must appear, and line 3's three omissions must all appear.
+- `No streaks, no scores, no reminders.` is a **statement of fact about the product**,
+  not reassurance about the user. It does not say "no judgment", "no pressure", or "no
+  guilt" — those frame the user's feelings (banned: motivational/emotional copy) rather
+  than the app's behavior. State what the app does not do; do not address how the user
+  should feel about it.
+- The existing one-line tagline `Track your temptations, understand your patterns.` is
+  **superseded** by the premise lines above and should not also appear on the intro (it
+  would duplicate line 2). It may remain only if the ux-designer keeps a separate
+  identity/title treatment; the premise lines are the canonical intro copy.
+- No "Welcome", no "Get started", no "Let's begin" — these are warmth/persona framing.
+  The forward control is the neutral `Continue`.
+- No emoji. No exclamation points. No second-person encouragement.
 
 ### S1: Log Screen (default tab)
 
@@ -2028,11 +2261,19 @@ User-defined. Managed via the `ContextTag` SwiftData model. Users create and del
 - Delete alert: "Delete all data?" / "This removes all habits, events, and settings. This cannot be undone." / "Delete Everything"
 
 **Onboarding:**
+
+_Intro step (new — see S0 Onboarding Intro):_
 - "Resistor"
-- "Track your temptations, understand your patterns."
+- "Log each moment a temptation hits, and whether you resisted or gave in."
+- "Over time, Resistor shows you the patterns: when temptations cluster and how often you resist."
+- "No streaks, no scores, no reminders."
+- "Continue"
+
+_First-habit step (existing):_
 - "What habit are you working on?"
 - "e.g., Sugar, Smoking, Social Media"
 - "Create habit and start logging" / "Skip for now"
+- Note: the old tagline "Track your temptations, understand your patterns." is superseded by the intro premise lines and should not also appear on the intro step.
 
 **Outcome Display Names:**
 - resisted -> "Resisted"
@@ -2202,6 +2443,48 @@ Guidelines, not gates. No CI to enforce.
 - VoiceOver must complete every flow
 - Habit cards, stat cards, chart containers grouped as single accessible elements
 - Custom labels for: log button ("Log temptation for [habit name]"), carousel arrows, intensity circles, outcome buttons
+
+#### Onboarding Intro (VoiceOver and Dynamic Type)
+
+- The intro is read-only explanatory text plus one forward control. VoiceOver reads the
+  app name, then the premise lines, then `Continue` (trait `.isButton`, on activate
+  advances to the first-habit step). The premise lines may be grouped so VoiceOver reads
+  them as one block followed by the button — the ux-designer decides grouping; no premise
+  line may be hidden from VoiceOver.
+- The forward control's hit target is ≥44×44pt.
+- All intro text honors Dynamic Type and must remain fully readable (no truncation, no
+  clipping) at the largest accessibility text sizes; the intro fits one screen at default
+  sizes and may scroll at the largest sizes rather than truncate. Any decorative
+  animation on the intro is gated on Reduce Motion (no motion is required for the intro
+  to function).
+
+**Concrete accessibility spec (build-ready):**
+
+- **VoiceOver reading order.** The decorative mark is `.accessibilityHidden(true)`.
+  Order is: (1) `"Resistor"` (the app-name `Text`), then (2) the premise block, then
+  (3) the `Continue` button. The three premise lines are wrapped in
+  `.accessibilityElement(children: .combine)` so VoiceOver reads them as **one** block:
+  `"Log each moment a temptation hits, and whether you resisted or gave in. Over time,
+  Resistor shows you the patterns: when temptations cluster and how often you resist. No
+  streaks, no scores, no reminders."` No premise line is hidden. (Reading them combined
+  avoids three separate swipe stops for what is one continuous statement; the visual
+  20pt gaps are presentational, not semantic boundaries.)
+- **Continue button.** Standard `Button` so it carries `.isButton` automatically. Label
+  is its text, `"Continue"`. No custom hint needed (the action is self-evident and the
+  intro makes no promise to qualify). Hit target is the full-width button, comfortably
+  ≥44×44pt (20pt vertical padding around a `.title2` label).
+- **Dynamic Type reflow.** Because the intro lives in a `ScrollView`, growing text
+  pushes content taller and the screen scrolls rather than truncating — the explicit
+  reflow answer to the one-screen density risk. `.fixedSize(horizontal: false, vertical:
+  true)` on every `Text` guarantees full wrapping at all sizes. No fixed heights anywhere
+  in the intro (no `.frame(height:)` on text or the button), so nothing clips large text.
+  At the largest accessibility sizes the identity mark may optionally shrink via
+  `@ScaledMetric` or simply scroll off above the fold — either is acceptable; the
+  premise text and `Continue` must never clip.
+- **Reduce Motion.** The step-to-step transition is the only motion on the intro and is
+  gated on `@Environment(\.accessibilityReduceMotion)`: slide+fade when off, plain
+  cross-fade or no animation when on (see Intro layout: Transition / Reduce Motion
+  variant above).
 
 #### Time-of-Day Drill-Down (VoiceOver)
 


### PR DESCRIPTION
## Summary

Onboarding (S0) previously dropped first-run users straight into creating their first habit with no framing of what Resistor is. Because the app's model is deliberately unusual — you log moments of temptation/resistance, not streaks — the absent gamification read as missing features rather than intentional design. This adds a single premise screen before the first-habit step.

The intro conveys three things in clinical voice:
- **what you record** — the moment + outcome (resisted / gave in)
- **what you get back** — pattern visibility over time
- **what it deliberately is not** — no streaks, no scores, no reminders

## How it works

- S0 becomes a two-step flow inside the existing `NavigationStack` (`intro` → `firstHabit`) via a step enum. The entire first-habit body moves **verbatim** into the second step.
- The intro writes nothing — `Continue` only advances the step, so `hasCompletedOnboarding` is still set solely by the existing create/skip paths. First-run-only behavior is unchanged (reappears only after Delete All Data).
- The old `Track your temptations, understand your patterns.` tagline is removed (superseded by the premise copy).
- **No ViewModel change.**

## Design / accessibility

- Semantic colors only — dark mode correct, system-blue tint on first run (nil accent).
- Step transition (slide + fade) gated on Reduce Motion → plain cross-fade.
- Premise block combined for a single VoiceOver utterance; screen scrolls (not clips) at the largest Dynamic Type sizes.
- Clinical tone enforced: states facts about the product, no motivational / reassurance copy, no "Welcome", no exclamation points, no emoji.

## Tests

- `254/254` green (added `OnboardingGatingTests`, 6 tests, covering the complete/skip gate and the first-run lifecycle including Delete-All-Data reset).
- `DataExporterTests` green (13/13) — checked separately.
- DEBUG-only `-uiTestOnboarding` harness hook added to render first-run state for snapshots; production paths untouched. Verified in light, dark, and XXXL Dynamic Type.

Built via the product → design → implement → test → ui-iterator pipeline. `docs/design.md` updated (Flow 0, S0 spec, copy, VoiceOver/Dynamic Type notes).

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)