### PR TITLE
Fix red CI: align to Xcode 26 and split habitCard expression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,25 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Match the local/dev toolchain (CLAUDE.md): Xcode 26, iPhone 17 Pro /
+      # iOS 26. The macos-15 image ships Xcode 26.3. Keeping CI on the same
+      # Swift compiler as local builds avoids type-checker divergence — Xcode
+      # 16.4's solver timed out on LogView's habit card; 26's does not.
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
+
+      # The Resistor scheme embeds the watchOS app (Embed Watch Content), so the
+      # iOS test action also builds the watch app and needs the watchOS simulator
+      # runtime present (see CLAUDE.md "Build & Development").
+      - name: Install watchOS runtime
+        run: xcodebuild -downloadPlatform watchOS
 
       - name: Build
         run: |
           xcodebuild build-for-testing \
             -project Resistor.xcodeproj \
             -scheme Resistor \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
             -quiet
 
       - name: Test
@@ -32,5 +42,5 @@ jobs:
           xcodebuild test-without-building \
             -project Resistor.xcodeproj \
             -scheme Resistor \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
             -quiet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,12 @@ xcodebuild -project Resistor.xcodeproj \
 
 **Simulator:** iPhone 17 Pro (iOS 26). Do not use iPhone 16 runtimes.
 **Physical device:** iPhone 16 Pro.
-**No CI/CD.** Local builds only.
+**CI:** GitHub Actions (`.github/workflows/ci.yml`) build-and-tests every PR and
+push to `main` on a `macos-15` runner. It pins **Xcode 26.3** and the **iPhone 17
+Pro** simulator to match local builds — keep CI and local on the same Xcode 26
+toolchain so the Swift type-checker behaves identically (Xcode 16.4's solver timed
+out on `LogView`'s habit card; 26's does not). The workflow downloads the watchOS
+runtime before testing because the scheme embeds the watch app (see below).
 **Test target:** `ResistorTests` — unit tests for ViewModels, Models, and Services.
 
 **watchOS runtime required for the iOS test action.** The `Resistor` scheme now

--- a/Resistor/Views/LogView.swift
+++ b/Resistor/Views/LogView.swift
@@ -301,7 +301,6 @@ struct LogView: View {
         }
     }
 
-    @ViewBuilder
     private func habitCard(_ habit: Habit, vm: LogViewModel) -> some View {
         let habitColor = Color(hex: habit.colorHex ?? "#007AFF") ?? .blue
         let cardScale = reduceMotion ? 1.0 : 1.0 + (holdProgress * 0.08)
@@ -312,7 +311,16 @@ struct LogView: View {
         // hold effect's progress/glow rings render on top of this.
         let restBorderOpacity: CGFloat = isHolding ? 0 : 0.55
 
-        VStack(spacing: 16) {
+        // The card is one heavily-decorated view (surface fill, resting border,
+        // two hold rings, a radiating ring, layered shadows, scale, accessibility,
+        // and gestures). Built as a single fluent chain it overwhelms the Swift
+        // type-checker — Xcode 16's solver times out ("unable to type-check this
+        // expression in reasonable time"). Splitting it across typed `let`
+        // bindings type-checks each sub-expression independently; the resulting
+        // view tree is identical.
+
+        // Inner content — icon, name, optional description.
+        let content = VStack(spacing: 16) {
             // Icon — gets its own glow during hold
             Image(systemName: habit.iconName ?? "circle.fill")
                 .font(.system(size: 48))
@@ -340,130 +348,142 @@ struct LogView: View {
         }
         .padding(32)
         .frame(maxWidth: .infinity)
-        .background(
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color(.secondarySystemBackground))
-                .overlay(
-                    // Background tint intensifies during hold. Resting tint is a
-                    // touch stronger than before so the surface separates from
-                    // the canvas (notably the pure-black dark background).
-                    RoundedRectangle(cornerRadius: 20)
-                        .fill(habitColor.opacity(0.15 + holdProgress * 0.2))
-                )
-        )
-        .overlay(
-            // Resting affordance border — steady habit-color stroke that signals
-            // the card is the interactive log control and frames the surface.
-            RoundedRectangle(cornerRadius: 20)
-                .stroke(habitColor.opacity(restBorderOpacity), lineWidth: 1.5)
-        )
-        .overlay(
-            // Progress trim ring — shows exactly how far along the hold is
-            RoundedRectangle(cornerRadius: 20)
-                .trim(from: 0, to: holdProgress)
-                .stroke(habitColor, style: StrokeStyle(lineWidth: 3, lineCap: .round))
-                .opacity(isHolding ? 1 : 0)
-        )
-        .overlay(
-            // Pulsing glow border — breathes via repeating animation
-            RoundedRectangle(cornerRadius: 20)
-                .stroke(
-                    habitColor.opacity(holdProgress * glowPulseIntensity * 0.8),
-                    lineWidth: 2 + holdProgress * 3
-                )
-                .blur(radius: 4)
-                .opacity(isHolding ? 1 : 0)
-        )
-        // Radiating pulse ring — expands outward and fades (Hacking with Swift pattern)
-        .background(
-            RoundedRectangle(cornerRadius: 20)
-                .stroke(habitColor.opacity(0.4), lineWidth: 2)
-                .scaleEffect(isHolding && !reduceMotion ? 1.0 + holdProgress * 0.15 : 1.0)
-                .opacity(isHolding ? Double(1.0 - holdProgress) * 0.6 : 0)
-        )
-        // Layered shadow glow — tight inner + wide outer, pulse-modulated
-        .shadow(
-            color: habitColor.opacity(isHolding ? holdProgress * glowPulseIntensity * 0.5 : 0),
-            radius: isHolding ? 12 + holdProgress * 16 : 0
-        )
-        .shadow(
-            color: habitColor.opacity(isHolding ? holdProgress * glowPulseIntensity * 0.25 : 0),
-            radius: isHolding ? 30 + holdProgress * 30 : 0
-        )
-        .scaleEffect(cardScale)
-        .animation(reduceMotion ? .none : .easeOut(duration: 0.15), value: cardScale)
-        .zIndex(isHolding ? 1 : 0)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Log temptation for \(habit.name)")
-        .accessibilityValue("\(habit.todayEventsCount) logged today")
-        .accessibilityHint("Tap or hold to log a temptation")
-        .accessibilityAddTraits(.isButton)
-        // VoiceOver users can't perform the swipe-to-switch-habit drag, so expose
-        // the carousel's next/previous as named actions on the card itself (the
-        // visible arrows are also labelled, but only render with >1 habit).
-        .accessibilityActions {
-            if vm.habits.count > 1 {
-                Button("Next habit") { vm.selectNextHabit() }
-                Button("Previous habit") { vm.selectPreviousHabit() }
-            }
-        }
-        .padding(.horizontal, 24)
-        .offset(x: cardDragOffset)
-        .contentShape(RoundedRectangle(cornerRadius: 20))
-        .onTapGesture {
-            // Only handle tap if the drag gesture didn't trigger a hold
-            if !didHold {
-                logTemptationAction(vm)
-            }
-            didHold = false
-        }
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { value in
-                    let distance = sqrt(value.translation.width * value.translation.width + value.translation.height * value.translation.height)
 
-                    if distance > 30 {
-                        // User is swiping, cancel hold and handle carousel
-                        if isHolding {
-                            cancelHold(vm)
-                        }
-                        cardDragOffset = value.translation.width * 0.4
-                    } else if !isHolding && distance < 10 {
-                        // Finger staying still — start hold
-                        startHold(vm)
-                    }
+        // Surface fill + resting affordance border.
+        let filled = content
+            .background(
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(Color(.secondarySystemBackground))
+                    .overlay(
+                        // Background tint intensifies during hold. Resting tint is a
+                        // touch stronger than before so the surface separates from
+                        // the canvas (notably the pure-black dark background).
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(habitColor.opacity(0.15 + holdProgress * 0.2))
+                    )
+            )
+            .overlay(
+                // Resting affordance border — steady habit-color stroke that signals
+                // the card is the interactive log control and frames the surface.
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(habitColor.opacity(restBorderOpacity), lineWidth: 1.5)
+            )
+
+        // Hold-progress rings layered on top of the surface.
+        let ringed = filled
+            .overlay(
+                // Progress trim ring — shows exactly how far along the hold is
+                RoundedRectangle(cornerRadius: 20)
+                    .trim(from: 0, to: holdProgress)
+                    .stroke(habitColor, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    .opacity(isHolding ? 1 : 0)
+            )
+            .overlay(
+                // Pulsing glow border — breathes via repeating animation
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(
+                        habitColor.opacity(holdProgress * glowPulseIntensity * 0.8),
+                        lineWidth: 2 + holdProgress * 3
+                    )
+                    .blur(radius: 4)
+                    .opacity(isHolding ? 1 : 0)
+            )
+
+        // Radiating ring behind the card + layered shadow glow + scale.
+        let glowing = ringed
+            // Radiating pulse ring — expands outward and fades (Hacking with Swift pattern)
+            .background(
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(habitColor.opacity(0.4), lineWidth: 2)
+                    .scaleEffect(isHolding && !reduceMotion ? 1.0 + holdProgress * 0.15 : 1.0)
+                    .opacity(isHolding ? Double(1.0 - holdProgress) * 0.6 : 0)
+            )
+            // Layered shadow glow — tight inner + wide outer, pulse-modulated
+            .shadow(
+                color: habitColor.opacity(isHolding ? holdProgress * glowPulseIntensity * 0.5 : 0),
+                radius: isHolding ? 12 + holdProgress * 16 : 0
+            )
+            .shadow(
+                color: habitColor.opacity(isHolding ? holdProgress * glowPulseIntensity * 0.25 : 0),
+                radius: isHolding ? 30 + holdProgress * 30 : 0
+            )
+            .scaleEffect(cardScale)
+            .animation(reduceMotion ? .none : .easeOut(duration: 0.15), value: cardScale)
+            .zIndex(isHolding ? 1 : 0)
+
+        // Accessibility + gesture wiring as the final, lighter chain.
+        return glowing
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Log temptation for \(habit.name)")
+            .accessibilityValue("\(habit.todayEventsCount) logged today")
+            .accessibilityHint("Tap or hold to log a temptation")
+            .accessibilityAddTraits(.isButton)
+            // VoiceOver users can't perform the swipe-to-switch-habit drag, so expose
+            // the carousel's next/previous as named actions on the card itself (the
+            // visible arrows are also labelled, but only render with >1 habit).
+            .accessibilityActions {
+                if vm.habits.count > 1 {
+                    Button("Next habit") { vm.selectNextHabit() }
+                    Button("Previous habit") { vm.selectPreviousHabit() }
                 }
-                .onEnded { value in
-                    let distance = sqrt(value.translation.width * value.translation.width + value.translation.height * value.translation.height)
+            }
+            .padding(.horizontal, 24)
+            .offset(x: cardDragOffset)
+            .contentShape(RoundedRectangle(cornerRadius: 20))
+            .onTapGesture {
+                // Only handle tap if the drag gesture didn't trigger a hold
+                if !didHold {
+                    logTemptationAction(vm)
+                }
+                didHold = false
+            }
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        let distance = sqrt(value.translation.width * value.translation.width + value.translation.height * value.translation.height)
 
-                    if distance > 30 {
-                        // Swipe gesture ended — cancel any hold state
-                        didHold = false
-                        if value.translation.width > 50 {
-                            vm.selectPreviousHabit()
-                        } else if value.translation.width < -50 {
-                            vm.selectNextHabit()
-                        }
-                        if reduceMotion {
-                            cardDragOffset = 0
-                        } else {
-                            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-                                cardDragOffset = 0
+                        if distance > 30 {
+                            // User is swiping, cancel hold and handle carousel
+                            if isHolding {
+                                cancelHold(vm)
                             }
+                            cardDragOffset = value.translation.width * 0.4
+                        } else if !isHolding && distance < 10 {
+                            // Finger staying still — start hold
+                            startHold(vm)
                         }
-                    } else if isHolding {
-                        // Hold released — log temptation
-                        endHold(vm)
                     }
-                }
-        )
-        .onDisappear {
-            // Clean up timer if view disappears mid-hold
-            holdTimer?.invalidate()
-            holdTimer = nil
-            holdStartTime = nil
-        }
-        .animation(reduceMotion ? .none : .interactiveSpring, value: cardDragOffset)
+                    .onEnded { value in
+                        let distance = sqrt(value.translation.width * value.translation.width + value.translation.height * value.translation.height)
+
+                        if distance > 30 {
+                            // Swipe gesture ended — cancel any hold state
+                            didHold = false
+                            if value.translation.width > 50 {
+                                vm.selectPreviousHabit()
+                            } else if value.translation.width < -50 {
+                                vm.selectNextHabit()
+                            }
+                            if reduceMotion {
+                                cardDragOffset = 0
+                            } else {
+                                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                                    cardDragOffset = 0
+                                }
+                            }
+                        } else if isHolding {
+                            // Hold released — log temptation
+                            endHold(vm)
+                        }
+                    }
+            )
+            .onDisappear {
+                // Clean up timer if view disappears mid-hold
+                holdTimer?.invalidate()
+                holdTimer = nil
+                holdStartTime = nil
+            }
+            .animation(reduceMotion ? .none : .interactiveSpring, value: cardDragOffset)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Why

CI (`.github/workflows/ci.yml`, added Jun 19) has been **red on every run** — and each failed run on `main` sends a build-failure email. Root cause:

```
LogView.swift:305: error: the compiler is unable to type-check this
expression in reasonable time
** TEST BUILD FAILED **
```

CI pinned **Xcode 16.4 / iPhone 16 Pro**, whose type-checker times out on `habitCard` (the hold-to-log card is one ~20-modifier fluent chain). Local builds never caught it because they use **Xcode 26 / iPhone 17 Pro / iOS 26** (per CLAUDE.md), whose solver handles the expression fine.

## What changed

**1. Align CI to the local toolchain** (`ci.yml`)
- Select `/Applications/Xcode_26.3.app` and target `iPhone 17 Pro` — both present on the `macos-15` runner image. CI now runs the same Swift compiler as local dev, so they can't diverge again.
- Add an `xcodebuild -downloadPlatform watchOS` step: the `Resistor` scheme embeds the watch app (Embed Watch Content), so the iOS test action builds it and needs the watchOS runtime.

**2. Break up the offending expression** (`LogView.swift`)
- `habitCard` is split from one mega-chain into typed `let` bindings: `content → filled → ringed → glowing → final accessibility/gesture chain`. Each sub-expression type-checks independently. **The resulting view tree is identical** — the hold-to-log visual effect (surface fill, resting border, progress/glow rings, radiating ring, layered shadows, scale, gestures) is unchanged. Also speeds up local compiles. Verified: `** TEST BUILD SUCCEEDED **` locally on Xcode 26.5.

**3. Docs** (`CLAUDE.md`) — the stale "No CI/CD. Local builds only." note is replaced with the actual CI description.

## Verification
- Local `xcodebuild build-for-testing` (Xcode 26.5, iPhone 17 Pro): **TEST BUILD SUCCEEDED**.
- The real proof is this PR's own CI run going green — first green run since the workflow was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)