### PR TITLE
Undo a just-logged temptation by shaking the phone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,6 +420,22 @@ The Log screen's habit card supports both tap and hold-to-log. The hold interact
 
 All visual effects are gated on `!reduceMotion` for accessibility. The glow pulse uses SwiftUI's native animation system (not manual sine computation) for smooth interpolation.
 
+### Shake to Undo
+
+Shaking the phone while the confirmation banner is up undoes the log — the same
+gesture and the same 5s window as the watch, so the two devices don't disagree
+about how a mislog is taken back. On iOS this needs no Core Motion (the watch's
+`ShakeDetector` exists only because watchOS has no shake gesture): UIKit's
+`.motionShake` arrives on the responder chain, and a category override on
+`UIWindow` at the bottom of `LogView.swift` reposts it as a `Notification`.
+
+Two things there are load-bearing. It **calls `super`** — iOS's own
+shake-to-undo for text editing runs through the same path, and swallowing the
+event breaks it in the note and habit-name fields. And it is a **second path,
+not a replacement**: the banner keeps its Undo button, because Reduce Motion and
+motor-accessibility users can't shake and undo has to stay reachable without
+motion.
+
 ## CloudKit Constraints
 
 iCloud sync via SwiftData + CloudKit imposes these restrictions:

--- a/Resistor/Views/LogView.swift
+++ b/Resistor/Views/LogView.swift
@@ -311,6 +311,19 @@ struct LogView: View {
             }
         }
         .animation(reduceMotion ? .none : .easeInOut(duration: 0.3), value: vm.showConfirmation)
+        // Shake to undo, matching the watch: same gesture, same 5s window, so
+        // the two devices don't disagree about how a mislog is taken back. It
+        // is a second path to the banner's Undo button, never a replacement —
+        // Reduce Motion and motor-accessibility users can't shake, and undo
+        // has to stay reachable without motion.
+        .onReceive(NotificationCenter.default.publisher(for: .deviceDidShake)) { _ in
+            // Scoped to the banner's window. Outside it there is nothing to take
+            // back, and a shake anywhere else in the app means nothing here.
+            guard vm.showConfirmation else { return }
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+            vm.undoLastLog()
+            UIAccessibility.post(notification: .announcement, argument: "Log undone")
+        }
     }
 
     /// A quiet line that appears only when the clock is inside one of this
@@ -852,6 +865,26 @@ private struct FlowLayout: Layout {
 
         return (positions, CGSize(width: maxX, height: y + rowHeight))
     }
+}
+
+/// UIKit delivers a shake to the responder chain; SwiftUI exposes no equivalent,
+/// so this is the whole bridge. Overriding on `UIWindow` rather than hosting a
+/// first-responder view controller means the shake is seen no matter what holds
+/// first responder, and nothing has to fight SwiftUI for focus.
+///
+/// `super` is called deliberately: iOS's own shake-to-undo for text editing runs
+/// through this same path, and swallowing the event would break it in the note
+/// and habit-name fields.
+extension UIWindow {
+    open override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        super.motionEnded(motion, with: event)
+        guard motion == .motionShake else { return }
+        NotificationCenter.default.post(name: .deviceDidShake, object: nil)
+    }
+}
+
+extension Notification.Name {
+    static let deviceDidShake = Notification.Name("deviceDidShake")
 }
 
 #Preview {


### PR DESCRIPTION
Brings the phone in line with the watch, which has undone a mislog on a shake since #51. The phone made you find a small button on a banner that is only up for five seconds — the wrong ask while walking, which is exactly when this app gets used.

## How

iOS needs no Core Motion for this. The watch's `ShakeDetector` exists only because watchOS has no shake gesture; here `.motionShake` already arrives on the responder chain, so a category override on `UIWindow` reposts it as a `Notification` and the Log screen listens while its banner is up.

Two load-bearing details:

- **It calls `super`.** iOS's own shake-to-undo for text editing comes through the same path, and swallowing the event would break it in the note and habit-name fields.
- **The banner keeps its Undo button.** #54 proposed moving Undo onto the gesture to simplify the banner, but Reduce Motion and motor-accessibility users can't shake, so undo has to stay reachable without motion. The gesture is a second path, not a replacement.

Same 5s window as the watch, so the two devices don't disagree about how a mislog is taken back.

## Testing

`xcodebuild test -scheme Resistor` green. `undoLastLog` is already covered (`LogViewModelTests.swift:474`); the UIKit shake path itself isn't automatable — XCUITest has no shake API — so verify by hand with Device → Shake (⌃⌘Z) in the simulator, and check text-field shake-to-undo still works in a habit name.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sdMoCETcfDumJBdarLpba