### PR TITLE
Page between habits on the watch instead of opening a picker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ in Settings; a place is renamed or removed through the same sheet.
 |-------|------|-------|
 | `id` | `UUID` | No `@Attribute(.unique)` (CloudKit) |
 | `defaultHabitId` | `UUID?` | Which habit to show first on Log screen |
-| `showContextPrompt` | `Bool` | Whether context sheet appears after logging |
+| `showContextPrompt` | `Bool` | **Orphaned.** Gated the post-log context sheet, which no longer exists. Nothing reads or sets it — see Sheet Dismissal |
 | `accentColorHex` | `String?` | User-configurable accent color hex. Nil = system blue. |
 | `hasCompletedOnboarding` | `Bool` | Gates onboarding flow |
 
@@ -201,22 +201,38 @@ Views hold ViewModels as `@State private var viewModel: SomeViewModel?` and init
 
 ViewModels receive `ModelContext` via init, not environment.
 
-### Sheet Sequencing
+### Sheet Dismissal
 
-The Log screen presents two sheets in sequence: outcome -> context. Uses state flag + `onDismiss`:
+**Do not use `DispatchQueue.main.asyncAfter` to time anything off a sheet. Always
+use `onDismiss`.** Live referent: `LogView`'s Add Habit sheet rebuilds or refetches
+the view model in `onDismiss`.
 
-```swift
-.sheet(isPresented: $showOutcomeSheet, onDismiss: {
-    if shouldShowContextAfterOutcome {
-        shouldShowContextAfterOutcome = false
-        showContextSheet = true
-    } else {
-        vm.triggerConfirmation()
-    }
-}) { ... }
-```
+This entry used to document a two-sheet outcome → context sequence on the Log
+screen. **That flow no longer exists** — `showOutcomeSheet`,
+`showContextSheet` and `shouldShowContextAfterOutcome` are all gone. Logging
+defaults to `resisted` and is corrected afterward from the confirmation banner;
+context is chosen as inline chips *before* the tap. Nothing presents between the
+log tap and the banner, which is why the banner no longer needs sequencing at all.
 
-Do **not** use `DispatchQueue.main.asyncAfter` for sheet timing. Always use `onDismiss`.
+The rule survived its flow because the flow is *why* it exists: the banner
+originally fired on a guessed delay and landed behind the sheets it was supposed
+to follow. Any future sheet chain must still use `onDismiss`.
+
+**Three fields were orphaned when those sheets went, and none of it is visible
+from the models:**
+
+- `TemptationEvent.intensity` — no capture UI anywhere. Read-only in the History
+  detail; Insights' "Intensity Trend" card can only render against `UITestSeed`
+  data, never a real device's.
+- `TemptationEvent.note` — displayed in History and the export, written by no
+  view. `LogViewModel.updateEventContext(contextTags:note:)` still exists and is
+  unit-tested, with **no production caller**.
+- `UserSettings.showContextPrompt` — still defaulted, still merged by
+  `mergeDuplicates`, read by nothing.
+
+All three are live in the Production CloudKit schema (deployed 2026-07-31), so
+restoring capture for any of them needs UI only — no migration, no schema deploy.
+Don't delete them to "clean up": Production record fields can never be removed.
 
 ### Color Handling
 
@@ -489,10 +505,14 @@ it lived at SwiftData's default `Library/Application Support/default.store`, and
 **pointing a configuration at a new URL does not move the file** — it opens a
 new, empty one and strands the old.
 
-That has not fired yet, because the App Groups capability still isn't enabled on
-the **Resistor** target (issue #47), so `storeURL` returns nil at runtime and
-the code silently falls back to the old location. Ticking that checkbox is
-therefore a data migration, not a capability change.
+**The capability is now enabled and the migration path is live** (as of
+`308c8a2`, 2026-08-01). `Resistor.entitlements` declares
+`group.com.resistor.app` in both Debug and Release, `ResistorWidget` declares it
+too, and both provisioning profiles carry it — verified by decoding them, so the
+App ID has the capability and signing isn't stripping the entitlement. That
+means `storeURL` returns a real URL, and the *first launch after updating* is
+the migration.
+
 `resolvedStoreURL(groupStore:)` handles it: if the App Group has no store and a
 legacy one exists, it copies the `.store` **and its `-shm`/`-wal` sidecars**
 across, and opens the *legacy* store in place if the copy throws — an app that
@@ -691,6 +711,12 @@ pointing at the same PNG (one image, no duplication). Keep the membership: a
 shipped watch app needs an icon, and App Store validation rejects icons with an
 **alpha channel** (verify with `sips -g hasAlpha`).
 
+The `com.resistor.app.watchkitapp` App ID needs iCloud enabled with the
+`iCloud.com.resistor.app` container selected, **and** Push Notifications enabled
+(for the silent CloudKit sync push) — automatic signing won't mint a profile for
+an entitlement the App ID lacks, so a capability missing in the portal surfaces
+as a signing failure, not a sync bug. Both are set as of 2026-07-29.
+
 **Correction (2026-07-29):** an earlier version of this note claimed a missing
 icon was what made the install ring fill and then revert to "Install". That was
 wrong — a guess from a plausible detail, never verified. The actual cause was
@@ -810,28 +836,39 @@ coexist on disk; each mode only cleans its own files.
 
 ## Open GitHub Issues
 
-- #35 — App icon design
-- #37 — Accessibility pass (in progress — comprehensive VoiceOver/Dynamic Type sweep)
-- #47 — Quick-log widget: device verification + App Group / CloudKit capability setup
-- #48 — No haptics firing on device (tap impact + hold Core Haptics both silent)
-- #49 — watchOS app: wrist-fast resisted-temptation logging (post-v1, companion to widget)
-  - The `com.resistor.app.watchkitapp` App ID needs iCloud enabled with the
-    `iCloud.com.resistor.app` container selected, **and** Push Notifications
-    enabled (for the silent CloudKit sync push) — automatic signing won't mint a
-    profile for an entitlement the App ID lacks. Both are set as of 2026-07-29.
-  - **If the install ring completes and then reverts to "Install":** check that
-    the watch is a registered development device and appears in the profile's
-    `ProvisionedDevices`. That — not a missing icon — was the cause last time.
+Current as of 2026-08-03. Everything previously listed here (#35 icon, #37
+accessibility, #47 widget, #48 haptics, #49 watch) is closed.
 
-## Remaining Work (v1.0)
+- #53 — Log screen: surface multiple habits (scrollable list) to use the empty space
+- #60 — Default habit: make it the top of the reordered list, or drop it
+- #61 — Log screen: habit card content is top-justified, not centered
+- #62 — Log screen: habit pager sits above the card, should be below
+- #63 — Habit editor: expand icon and color choices (icon search)
+
+**Two of those closed without the device check they asked for**, which is worth
+knowing before trusting them:
+
+- **#47 (widget)** was closed on the signing artifacts alone. The widget's
+  runtime behaviour — configuration UI, tap-writes-one-event, debounce,
+  needs-reconfiguration states, VoiceOver — has never been exercised on
+  hardware.
+- **#37 (accessibility)** shipped its code changes (accent picker selected
+  trait, history row grouping, carousel dot labels) and closed with the
+  VoiceOver / Dynamic Type walkthrough deferred to manual QA. It has not been
+  run.
+
+## v1.0 Scope — all shipped
+
+Kept as a record of what v1 was. Nothing here is outstanding; open work lives in
+the section above.
 
 - ~~iCloud sync (CloudKit container setup + entitlements)~~ — Done: entitlements + CloudKit ModelConfiguration
 - ~~Unit + UI test targets~~ — Done: ResistorTests with 11 test files
 - ~~Tip jar (StoreKit 2 consumable IAPs)~~ — Done: TipJarViewModel + StoreKit config
-- App icon (minimalist shield) — Issue #35
+- ~~App icon~~ — Done: `Assets.xcassets/AppIcon.appiconset/AppIcon.png`, shared by the iOS and watch targets
 - ~~Dark mode audit~~ — Done: confirmation banner border, habit card contrast
-- ~~Accessibility pass (VoiceOver, Dynamic Type)~~ — Done: selected traits, event grouping, carousel labels
-- TestFlight build (requires Xcode: signing, CloudKit container, team ID)
+- ~~Accessibility pass (VoiceOver, Dynamic Type)~~ — Code done: selected traits, event grouping, carousel labels. On-device VoiceOver/Dynamic Type walkthrough still unrun (see Open GitHub Issues)
+- ~~TestFlight build~~ — Done: shipping. Release notes are hand-written per push to `main` in `TestFlight/WhatToTest.en-US.txt`
 
 ## Design Documents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -655,19 +655,48 @@ xcodebuild -project Resistor.xcodeproj \
 ```
 
 The watch app (`ResistorWatch/`) is a single-screen quick-log companion (issue
-#49). **Release logs** — a flick and a 3s hold both write an event, matching the
+#49), one vertical page per habit. **Release logs** — a flick and a 3s hold both write an event, matching the
 phone, where the ramp changes how it feels, not whether it commits. Holding past
 3s keeps buzzing until release.
 
-**Habit switching:** tapping the habit name (a chevron appears once there is more
-than one active habit) opens a full-screen list. Not a swipe across the button —
-that already owns press-and-hold, and the phone's carousel needed a 0.15s arming
-delay to stop every swipe flashing the hold visuals. The pick lives in memory
-only (`WatchLogStore.selectedHabitID`) and resets to the default habit on
-relaunch, exactly like the phone's Log screen; persisting a watch-local override
-would make the two devices disagree about what "the" habit is. Target resolution
-is pick → `UserSettings.defaultHabitId` → first in `Habit.displayOrder`, and a
-pick that gets archived falls back rather than logging to an archived habit.
+**Habit switching is a vertical page swipe or a turn of the Crown**, one habit
+per page, via `TabView` + `.tabViewStyle(.verticalPage)`. Its page dots are the
+affordance. An earlier version put a chevron on the habit name that opened a
+full-screen list, on the reasoning that the button already owned press-and-hold;
+a tap to open a sheet to pick a habit is three interactions for the one thing a
+wrist-fast app should make cheapest.
+
+**The log control has to be a `Button`, not a gesture, and that is the whole
+reason paging works.** A custom press gesture on the disc swallows every vertical
+drag: the swipe neither turns the page *nor* is distinguishable from a lift, so
+the release logs an event — verified, it does exactly that. A `Button` yields its
+touch to the enclosing scroll the moment it pans and fires `action` only on a
+release the scroll didn't take, which is precisely the distinction, for free. The
+hold ramp rides on `ButtonStyle.Configuration.isPressed` (`PressReporting`), which
+stays true for as long as the finger is down — so there is still no duration
+threshold, holding past 3s still buzzes until release, and a flick and a full
+hold both log. Don't reintroduce `onLongPressGesture`/`DragGesture` here, and
+don't try to fix the accidental log with a distance threshold of your own; that
+was tried first and the pager still never saw the drag.
+
+Pages are in `Habit.displayOrder`, so a drag on the phone's Habits screen is the
+order on the wrist. The pick lives in memory only
+(`WatchLogStore.selectedHabitID`) and resets to the default habit on relaunch,
+exactly like the phone's Log screen; persisting a watch-local override would make
+the two devices disagree about what "the" habit is. Target resolution is pick →
+`UserSettings.defaultHabitId` → first in `Habit.displayOrder`, and a pick that
+gets archived falls back rather than logging to an archived habit.
+
+Pager pages are deliberately **not** scrollable — a vertical scroll inside a
+vertically paged `TabView` fights it for the same drag and the same Crown. Only
+the single-habit and no-habit states keep the `ScrollView`.
+
+**The store refreshes on `NSPersistentStoreRemoteChange`, not just on resume.** A
+reorder on the phone reaches the watch as a silent CloudKit import; without the
+observer in `WatchLogStore.init` the pager keeps rendering the order it fetched
+at launch, so the user reorders on the phone, looks at the wrist, and sees the
+old order. `scenePhase` still refreshes on resume for imports that landed while
+the app was suspended.
 
 **Location:** the watch logs coordinates like the phone, via the *same*
 `Resistor/Services/LocationManager.swift` (CoreLocation and `CLGeocoder` both
@@ -683,17 +712,12 @@ prompts on first launch. `Place` naming is unaffected: nothing is written onto
 the event, so a watch-logged coordinate resolves to a named place on the phone
 retroactively.
 
-Two watch-specific traps, both load-bearing:
+One watch-specific trap, load-bearing:
 
 - **`CHHapticEngine` does not exist in the watchOS SDK.** The phone's continuous
   ramped pattern is approximated by a repeated discrete `WKHapticType.click` at a
   tightening gap. Don't try to port `LogViewModel`'s Core Haptics code; it cannot
   compile there.
-- **The hold gesture's `minimumDuration` is 86,400s on purpose.** A long press
-  that *succeeds* ends the gesture and reports the press as over while the finger
-  is still down, cutting the haptic off mid-hold. Setting it beyond any real press
-  means only `onPressingChanged` fires and `perform` is dead by design. Don't
-  "fix" it to 3s.
 
 Shake-to-undo (`ShakeDetector.swift`) deletes the last logged event within a 5s
 window, via Core Motion — watchOS has no shake gesture API. The accelerometer runs

--- a/ResistorWatch/WatchLogStore.swift
+++ b/ResistorWatch/WatchLogStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreData
 import SwiftData
 import Observation
 
@@ -51,6 +52,8 @@ final class WatchLogStore {
     /// target on this checkout. Same `LocationProviding` the phone uses.
     private let locationManager = LocationManager()
 
+    private var remoteChangeObserver: NSObjectProtocol?
+
     init() {
         if let container = try? WatchModelContainer.makeContainer() {
             self.modelContext = ModelContext(container)
@@ -58,6 +61,25 @@ final class WatchLogStore {
             self.modelContext = nil
         }
         refresh()
+
+        // A drag on the phone's Habits screen rewrites every `sortOrder` and
+        // reaches the watch as a CloudKit import, which lands in the store
+        // silently. Without this the pager keeps rendering the order it fetched
+        // at launch until the next resume — the user reorders on the phone,
+        // looks at the wrist, and sees the old order.
+        remoteChangeObserver = NotificationCenter.default.addObserver(
+            forName: .NSPersistentStoreRemoteChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refresh()
+        }
+    }
+
+    deinit {
+        if let remoteChangeObserver {
+            NotificationCenter.default.removeObserver(remoteChangeObserver)
+        }
     }
 
     /// Asks for when-in-use location once, so a wrist log can carry a fix like a
@@ -85,13 +107,14 @@ final class WatchLogStore {
             return
         }
 
-        habitOptions = activeHabits(in: context)
+        let active = activeHabits(in: context)
+        habitOptions = active
 
-        guard let habit = resolveTargetHabit(in: context) else {
+        guard let habit = resolveTargetHabit(among: active, in: context) else {
             // Distinguish (e) from (d): if a default was configured but is gone
             // and there's truly nothing to fall back to, it's "habit
             // unavailable"; otherwise there simply is no habit yet.
-            if hasConfiguredButMissingDefault(in: context) {
+            if let defaultID = defaultHabitId(in: context), !active.contains(where: { $0.id == defaultID }) {
                 state = .habitUnavailable
             } else {
                 state = .noHabit
@@ -99,7 +122,7 @@ final class WatchLogStore {
             return
         }
 
-        let count = todayResistedCount(for: habit, in: context)
+        let count = todayResistedCount(for: habit)
         state = .loggable(
             habitID: habit.id,
             name: habit.name,
@@ -178,8 +201,7 @@ final class WatchLogStore {
     /// if it's still live, else `UserSettings.defaultHabitId` if that points at a
     /// live non-archived habit, else the first non-archived habit in display
     /// order. Returns `nil` only when no non-archived habit exists at all.
-    private func resolveTargetHabit(in context: ModelContext) -> Habit? {
-        let active = activeHabits(in: context)
+    private func resolveTargetHabit(among active: [Habit], in context: ModelContext) -> Habit? {
         guard !active.isEmpty else { return nil }
 
         if let selectedHabitID,
@@ -210,19 +232,12 @@ final class WatchLogStore {
         return (try? context.fetch(descriptor))?.first?.defaultHabitId
     }
 
-    /// True when a default habit id was configured but no longer resolves to a
-    /// live non-archived habit. Used to choose state (e) over (d).
-    private func hasConfiguredButMissingDefault(in context: ModelContext) -> Bool {
-        guard let defaultID = defaultHabitId(in: context) else { return false }
-        return !activeHabits(in: context).contains { $0.id == defaultID }
-    }
-
     // MARK: - Count
 
     /// Today's *resisted* event count for `habit`, using the same calendar-day
     /// definition as `Habit.todayEventsCount` (events in the current calendar
     /// day) but filtered to the resisted outcome only.
-    func todayResistedCount(for habit: Habit, in context: ModelContext) -> Int? {
+    func todayResistedCount(for habit: Habit) -> Int? {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
         // Habit.safeEvents is the same source the phone counts from.

--- a/ResistorWatch/WatchLogView.swift
+++ b/ResistorWatch/WatchLogView.swift
@@ -28,12 +28,6 @@ struct WatchLogView: View {
     /// same deliberate pause on both devices. Holding longer is allowed and keeps
     /// the haptic going; the ramp just sits at full.
     private static let holdDuration: TimeInterval = 3.0
-    /// A `minimumDuration` no press will ever reach, so the long-press gesture
-    /// never succeeds and only reports pressing/not-pressing. A day, not
-    /// `.infinity` or `.greatestFiniteMagnitude` — those land in SwiftUI's
-    /// deadline arithmetic, and a non-finite deadline is a worse bet than a
-    /// number that is merely absurd.
-    private static let neverCompletes: TimeInterval = 86_400
 
     /// watchOS has no Core Haptics — `CHHapticEngine` is absent from the watchOS
     /// SDK entirely, so the phone's continuous pattern with ramped intensity and
@@ -73,7 +67,6 @@ struct WatchLogView: View {
     /// available for exactly as long as a shake is.
     @State private var canUndo = false
     @State private var shakeDetector = ShakeDetector()
-    @State private var showHabitPicker = false
 
     // MARK: Hold state
     @State private var isHolding = false
@@ -86,11 +79,7 @@ struct WatchLogView: View {
     @State private var glowPulsing = false
 
     var body: some View {
-        ScrollView {
-            content
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 4)
-        }
+        content
         .onAppear {
             if vm == nil {
                 vm = WatchLogStore()
@@ -101,21 +90,13 @@ struct WatchLogView: View {
             // screen, so a log has a fix to attach.
             vm?.requestLocationPermissionIfNeeded()
         }
-        .sheet(isPresented: $showHabitPicker) {
-            if let vm {
-                habitPicker(vm)
-            }
-        }
         .onChange(of: scenePhase) { _, phase in
             // Re-read the count on resume. `onAppear` does not fire again when the
             // app returns from background, so without this a CloudKit import that
             // landed while suspended stays invisible — the count would show the
-            // value from whenever the view was first built.
-            //
-            // ponytail: resume only. An import that lands while the app is already
-            // frontmost still won't show until the next resume; catching that needs
-            // NSPersistentStoreRemoteChange observation. Add it only if a stale
-            // count is actually noticed in use — a watch glance is a resume.
+            // value from whenever the view was first built. Imports that land
+            // while the app is frontmost are caught by the store's
+            // `NSPersistentStoreRemoteChange` observer instead.
             guard phase == .active else {
                 // Dropping the wrist mid-hold would otherwise strand the haptic
                 // timer, buzzing with the app no longer frontmost — and leave the
@@ -137,25 +118,69 @@ struct WatchLogView: View {
     private var content: some View {
         if let vm {
             switch vm.state {
-            case let .loggable(_, name, colorHex, iconName, count):
-                loggable(vm, name: name, colorHex: colorHex, iconName: iconName, count: count)
+            case let .loggable(habitID, name, colorHex, iconName, count):
+                if vm.habitOptions.count > 1 {
+                    // One habit per page, swiped up/down or turned in with the
+                    // Crown — `.verticalPage` wires both, and its page dots are
+                    // the affordance the old chevron-and-sheet was standing in
+                    // for. Pages are in `Habit.displayOrder`, so a drag on the
+                    // phone's Habits screen is the order on the wrist.
+                    TabView(selection: habitSelection(vm, current: habitID)) {
+                        ForEach(vm.habitOptions) { habit in
+                            loggable(
+                                vm,
+                                name: habit.name,
+                                colorHex: habit.colorHex,
+                                iconName: habit.iconName,
+                                count: vm.todayResistedCount(for: habit)
+                            )
+                            .tag(habit.id)
+                        }
+                    }
+                    .tabViewStyle(.verticalPage)
+                } else {
+                    page {
+                        loggable(vm, name: name, colorHex: colorHex, iconName: iconName, count: count)
+                    }
+                }
             case .noHabit:
-                nonLoggable(
-                    symbol: "square.dashed",
-                    title: "No habit to log",
-                    subtitle: "Add a habit on your phone"
-                )
+                page {
+                    nonLoggable(
+                        symbol: "square.dashed",
+                        title: "No habit to log",
+                        subtitle: "Add a habit on your phone"
+                    )
+                }
             case .habitUnavailable:
-                nonLoggable(
-                    symbol: "exclamationmark.triangle",
-                    title: "Habit unavailable",
-                    subtitle: "Set a default habit on your phone"
-                )
+                page {
+                    nonLoggable(
+                        symbol: "exclamationmark.triangle",
+                        title: "Habit unavailable",
+                        subtitle: "Set a default habit on your phone"
+                    )
+                }
             }
         } else {
             // Pre-init frame; render nothing rather than a flash of wrong state.
             Color.clear.frame(height: 1)
         }
+    }
+
+    /// Scrolling wrapper for the single-page states. The pager's own pages are
+    /// deliberately *not* scrollable — a vertical scroll inside a vertically
+    /// paged `TabView` fights it for the same drag and the same Crown.
+    private func page<Inner: View>(@ViewBuilder _ inner: () -> Inner) -> some View {
+        ScrollView {
+            inner()
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 4)
+        }
+    }
+
+    /// Selection is read straight off the resolved state rather than mirrored in
+    /// a `@State`, so the pager can't drift from the habit the button logs to.
+    private func habitSelection(_ vm: WatchLogStore, current: UUID) -> Binding<UUID> {
+        Binding(get: { current }, set: { vm.select(habitID: $0) })
     }
 
     // MARK: - (a)/(b)/(c)/(f) Loggable
@@ -169,40 +194,35 @@ struct WatchLogView: View {
         let dim = reduceMotion ? 0.0 : Double(holdProgress) * 0.5
 
         VStack(spacing: 8) {
-            habitName(vm, name: name)
+            habitName(name: name)
                 .opacity(1 - dim)
 
-            ZStack {
-                logButton(habitColor: habitColor, symbol: symbol)
-                acknowledgement
-            }
-            .frame(maxWidth: .infinity)
-            .frame(width: buttonContainerWidth)
-            // ONE gesture drives tap and hold alike: press starts the ramp,
-            // release logs. There is no completion threshold, so `perform` has no
-            // job — and `minimumDuration` is set far beyond any real press
-            // precisely so it never fires. A long press that *succeeds* ends the
-            // gesture, which would report the press as over while the finger is
-            // still down: the buzz would cut out at 3s instead of continuing
-            // until release, which is the opposite of what's wanted.
-            .onLongPressGesture(
-                minimumDuration: Self.neverCompletes,
-                maximumDistance: 20,
-                perform: {},
-                onPressingChanged: { pressing in
-                    if pressing { startHold() } else { releaseHold() }
+            // A real `Button`, not a gesture. That is the whole reason the pager
+            // works: a custom gesture on the button swallowed every vertical
+            // drag, so a swipe on the disc — the obvious place to put a finger —
+            // both failed to turn the page and logged an event on release. A
+            // Button yields its touch to the enclosing scroll the moment it
+            // pans, and `action` only fires on a release the scroll didn't take.
+            // So "swiped away" and "lifted" stop being indistinguishable, with
+            // no distance arithmetic of our own.
+            //
+            // The ramp rides on `isPressed`, which stays true for as long as the
+            // finger is down — no duration threshold, so holding past the end
+            // keeps buzzing until release, and a flick and a three-second hold
+            // both log.
+            Button(action: performLog) {
+                ZStack {
+                    logButton(habitColor: habitColor, symbol: symbol)
+                    acknowledgement
                 }
-            )
-            // Belt and braces for the primary path: if a very quick tap doesn't
-            // register as a press at all, this still logs it. A tap that fires
-            // both paths is harmless — the `isLogging` debounce swallows the
-            // second.
-            .onTapGesture(perform: performLog)
-            .accessibilityElement(children: .ignore)
-            .accessibilityAddTraits(.isButton)
+                .frame(maxWidth: .infinity)
+                .frame(width: buttonContainerWidth)
+            }
+            .buttonStyle(PressReporting { pressing in
+                if pressing { startHold() } else { endHold() }
+            })
             .accessibilityLabel(buttonAccessibilityLabel(name: name, count: count))
             .accessibilityHint("Logs a resisted temptation.")
-            .accessibilityAction { performLog() }
             // Shake is a motion-only affordance, which is no use to someone who
             // can't shake their wrist reliably — or who would trigger it by
             // accident. Offer the same undo as a VoiceOver action while the window
@@ -220,67 +240,16 @@ struct WatchLogView: View {
         .padding(.horizontal, 4)
     }
 
-    /// The habit's name — and, when there is more than one to log against, the
-    /// control that changes it. A separate tap target above the button rather
-    /// than a swipe across it: the button already owns press-and-hold, and the
-    /// phone's carousel swipe needed a 0.15s arming delay to stop every swipe
-    /// flashing the hold visuals. There is nothing to arm here.
-    @ViewBuilder
-    private func habitName(_ vm: WatchLogStore, name: String) -> some View {
-        let label = Text(name)
+    /// The habit's name. Just a label now — changing habit is the page swipe,
+    /// not a control.
+    private func habitName(name: String) -> some View {
+        Text(name)
             .font(.headline)
             .fontWeight(.semibold)
             .foregroundStyle(.primary)
             .multilineTextAlignment(.center)
             .lineLimit(2)
             .minimumScaleFactor(0.8)
-
-        if vm.habitOptions.count > 1 {
-            Button {
-                showHabitPicker = true
-            } label: {
-                HStack(spacing: 4) {
-                    label
-                    Image(systemName: "chevron.down")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .buttonStyle(.plain)
-            .accessibilityHint("Changes which habit you're logging.")
-        } else {
-            label
-        }
-    }
-
-    /// Full-screen list of the habits the watch can log against. watchOS has no
-    /// room for the phone's carousel, and a `Picker` would need the Crown while
-    /// the screen's one scroll view already wants it.
-    private func habitPicker(_ vm: WatchLogStore) -> some View {
-        let current: UUID? = {
-            if case let .loggable(habitID, _, _, _, _) = vm.state { return habitID }
-            return nil
-        }()
-
-        return List(vm.habitOptions) { habit in
-            Button {
-                vm.select(habitID: habit.id)
-                showHabitPicker = false
-            } label: {
-                HStack(spacing: 8) {
-                    Image(systemName: habit.iconName ?? "circle.fill")
-                        .foregroundStyle(Color(hex: habit.colorHex ?? "#007AFF") ?? .blue)
-                    Text(habit.name)
-                        .lineLimit(2)
-                    Spacer(minLength: 4)
-                    if habit.id == current {
-                        Image(systemName: "checkmark")
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            }
-            .accessibilityAddTraits(habit.id == current ? [.isButton, .isSelected] : .isButton)
-        }
     }
 
     /// The habit-color disc, with the hold effect layered over and behind it.
@@ -447,16 +416,6 @@ struct WatchLogView: View {
         scheduleHapticTick()
     }
 
-    /// Finger lifted — the log happens here, at whatever progress the ramp
-    /// reached. A flick and a full three-second hold both log; the ramp only ever
-    /// changed how it felt getting there.
-    private func releaseHold() {
-        let wasHolding = isHolding
-        endHold()
-        guard wasHolding else { return }
-        performLog()
-    }
-
     /// Tears down the hold without logging. Idempotent: fires on release, on
     /// backgrounding, and on disappear.
     private func endHold() {
@@ -575,6 +534,20 @@ struct WatchLogView: View {
             } else {
                 withAnimation(.easeIn(duration: 0.2)) { ack = nil }
             }
+        }
+    }
+
+    /// Reports the button's press state and draws nothing of its own — the label
+    /// already renders the entire hold effect, and the stock styles would layer
+    /// their own background and press-dimming underneath it.
+    private struct PressReporting: ButtonStyle {
+        let onPressingChanged: (Bool) -> Void
+
+        func makeBody(configuration: Configuration) -> some View {
+            configuration.label
+                .onChange(of: configuration.isPressed) { _, pressing in
+                    onPressingChanged(pressing)
+                }
         }
     }
 

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,20 +1,18 @@
-Shake to undo a log.
+Apple Watch: swipe or turn the Crown to change habits.
 
-Log a temptation, then shake the phone while the confirmation banner is still
-up — the log is deleted, same as tapping Undo. The Undo button is still there;
-the shake is a second way to reach it, not a replacement. Shake-to-undo while
-editing a habit name or a note should still undo text, as it always did.
+The habit name on the watch no longer has a drop-down. Each habit is its own
+page — swipe up and down, or turn the Digital Crown, to move between them. Dots
+on the right edge show where you are.
 
-This build also repairs three things on first launch. Check them before logging
-anything new:
+Worth checking:
 
-- Your habits and your full history should be intact. This is the build that
-  moves the database into shared storage so the widget can read it; the old copy
-  is left in place untouched as a fallback.
-- The default context tags (Stressed, Bored, Alone, On Phone, With Friends)
-  should each appear exactly once on the Log screen, not twice.
-- The app should pick the same default habit every launch rather than changing
-  its mind between launches.
+- Swiping with your finger starting on the big coloured button should change the
+  habit and NOT log anything. Watch the "Today: N logged" line to be sure.
+- A quick tap still logs. A three-second hold still ramps up (ring, glow,
+  escalating buzz) and logs on release, and holding longer keeps buzzing.
+- Reorder your habits on the phone (Habits screen, Edit, drag). The watch should
+  show the new order without you relaunching it — give iCloud a few seconds.
+- The watch still starts on your default habit, and a habit you pick on the
+  watch still resets to the default when you relaunch.
 
-If habits or history look wrong, stop and say so before logging — the previous
-copy of the data is still on the device and recoverable.
+Nothing changed on the phone in this build.


### PR DESCRIPTION
The watch's habit name carried a chevron that opened a full-screen list — three interactions to change the one thing a wrist-fast app should make cheapest. Habits are now one vertical page each, swiped up/down or turned in with the Crown, page dots as the affordance.

## The log control had to become a real `Button`

Keeping the custom press gesture and adding swipe-distance arithmetic was tried first and **failed both ways** in the simulator: the gesture swallowed the vertical drag, so the swipe neither turned the page nor was distinguishable from a lift — and the release logged an event.

A `Button` yields its touch to the enclosing scroll the moment it pans, and fires `action` only on a release the scroll didn't take. That is exactly the distinction, for free. The hold ramp rides on `ButtonStyle.Configuration.isPressed`, so there is still no duration threshold: a flick and a three-second hold both log, and holding past the ramp keeps buzzing until release.

## Reorder now lands without a relaunch

Pages already sorted by `Habit.displayOrder`; what was missing was freshness. A reorder on the phone reaches the watch as a silent CloudKit import that nothing was listening for, so the pager kept the order it fetched at launch until the next resume. `WatchLogStore` now observes `NSPersistentStoreRemoteChange`.

## Verification

In the watch simulator (Series 11, 46mm), with three seeded habits:

- swipe starting **on the disc** → pages, count stays 0 ✅
- tap → logs to the selected habit ✅
- 3s hold → ring/glow/dimming ramp, logs on release ✅

Still needs the paired device: the Digital Crown (the simulator can't turn it, though `.verticalPage` binds it natively) and the CloudKit reorder round-trip.

Also updates `CLAUDE.md`, which documented the drop-down and explicitly ruled out swiping, and writes the TestFlight notes for this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sdMoCETcfDumJBdarLpba