### PR TITLE
Center the habit card's content and put its pager below it

### DIFF
--- a/Resistor/Views/LogView.swift
+++ b/Resistor/Views/LogView.swift
@@ -232,17 +232,10 @@ struct LogView: View {
                 Spacer(minLength: 0)
                     .frame(maxHeight: 96)
 
-                // Current habit card cluster — pager sits directly above the
-                // card it controls so the relationship reads as one unit.
+                // Current habit card cluster.
                 if let habit = vm.selectedHabit {
                     if let pattern = vm.activePattern {
                         patternHeadsUp(pattern)
-                            .opacity(1.0 - dimAmount)
-                            .padding(.bottom, 16)
-                    }
-
-                    if vm.habits.count > 1 {
-                        habitCarousel(vm)
                             .opacity(1.0 - dimAmount)
                             .padding(.bottom, 16)
                     }
@@ -265,6 +258,16 @@ struct LogView: View {
                         .foregroundStyle(.secondary)
                         .padding(.top, 14)
                         .opacity(1.0 - dimAmount)
+
+                    // Pager below the content it pages, per `UIPageControl` and
+                    // `TabView(.page)`. The card and its "tap or hold" caption
+                    // are one unit; the pager navigates between those units, so
+                    // it sits under the pair rather than splitting them.
+                    if vm.habits.count > 1 {
+                        habitCarousel(vm)
+                            .padding(.top, 16)
+                            .opacity(1.0 - dimAmount)
+                    }
 
                     // Context tags (pre-select before logging)
                     if !contextTags.isEmpty {
@@ -415,6 +418,18 @@ struct LogView: View {
         // description gets a card the exact size of one that has a description.
         let rawDescription = habit.habitDescription ?? ""
         let description = rawDescription.isEmpty ? " " : rawDescription
+        // …and that reserve is all below the name, so an undescribed card drew
+        // its icon+name at the top over a dead band. Slide them down half of it.
+        // An `offset` because it moves pixels without touching layout: the card
+        // still measures identically to a described one, which is what
+        // `testHabitCardSizeIsIndependentOfDescription` pins. Rebalancing the
+        // padding or splitting the reserve into a blank line above and below
+        // both change the height (two one-line reserves run 1.7pt over one
+        // two-line reserve) — a point of slop in a nudge is invisible, a point
+        // in the height resizes a page mid-slide.
+        let blankDescriptionShift: CGFloat = rawDescription.isEmpty
+            ? (UIFont.preferredFont(forTextStyle: .body).lineHeight * 2 + 16) / 2
+            : 0
         let cardScale = reduceMotion ? 1.0 : 1.0 + (holdProgress * 0.08)
         let glowPulseIntensity: CGFloat = glowPulsing ? 1.0 : 0.5
         // Resting affordance: a steady habit-color border so the card reads as
@@ -471,6 +486,7 @@ struct LogView: View {
                 .lineLimit(2, reservesSpace: true)
                 .padding(.horizontal)
         }
+        .offset(y: blankDescriptionShift)
         .padding(32)
         .frame(maxWidth: .infinity)
 

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,18 +1,20 @@
-Apple Watch: swipe or turn the Crown to change habits.
+Log screen: two layout corrections.
 
-The habit name on the watch no longer has a drop-down. Each habit is its own
-page — swipe up and down, or turn the Digital Crown, to move between them. Dots
-on the right edge show where you are.
+The habit pager (arrows and dots) has moved from above the habit card to below
+it, under the "Tap or hold to log" line — where iOS normally puts page dots.
+
+The card's icon and name were sitting high, with empty space under them, on any
+habit with no description. They're now centred in the card.
 
 Worth checking:
 
-- Swiping with your finger starting on the big coloured button should change the
-  habit and NOT log anything. Watch the "Today: N logged" line to be sure.
-- A quick tap still logs. A three-second hold still ramps up (ring, glow,
-  escalating buzz) and logs on release, and holding longer keeps buzzing.
-- Reorder your habits on the phone (Habits screen, Edit, drag). The watch should
-  show the new order without you relaunching it — give iCloud a few seconds.
-- The watch still starts on your default habit, and a habit you pick on the
-  watch still resets to the default when you relaunch.
+- With more than one habit, the pager reads as belonging to the card below it
+  rather than to whatever is above it. Arrows and dots still work.
+- Make a habit with no description at all. Its icon and name should sit in the
+  middle of the card, not near the top.
+- Swipe between a habit that has a description and one that doesn't. The card
+  must not change size or jump mid-swipe — that's the thing most at risk here.
+- Nothing below the card moved: context chips and "Today: N logged" should sit
+  exactly where they did before.
 
-Nothing changed on the phone in this build.
+Nothing changed on the Apple Watch in this build.


### PR DESCRIPTION
Closes #61, closes #62 — both Log screen layout, both in `LogView.swift`.

## #61 — card content was top-justified

A habit with no description still reserves two body lines, so every page
measures the same. But the whole reserve sat *below* the name, so the visible
icon+name cluster rode at the top of the card over a dead band.

Fixed with an `offset` on the inner stack: it moves pixels without touching
layout, so the card measures exactly as it did before. That matters — the card
is a swipeable page, and a height that varies per habit resizes the page
mid-slide.

Two other approaches were tried first and both moved the height, which
`testHabitCardSizeIsIndependentOfDescription` caught (216.0 vs 217.67): moving
padding from the bottom to the top, and splitting the reserve into a blank line
above and below. Two one-line reserves don't add up to one two-line reserve.

## #62 — pager above the card it controls

Moved below, per `UIPageControl` / `TabView(.page)`. It goes under the card
*and* its "Tap or hold to log" caption — those two read as one unit, and the
pager navigates between units rather than splitting one.

The column contains the same elements with the same spacing, so its total
height is unchanged and nothing below the card moved (verified against the
pre-change capture — context chips and "Today: N logged" are pixel-identical).

## Verification

- `xcodebuild test` — 315 unit tests + the UITest assertions, all passing.
- Screenshots via `ui-quickshot.sh` in four cases: described / undescribed card,
  light / dark. The undescribed case needed a temporary seed edit, since both
  seeded habits carry a description; the seed is unchanged on this branch.

Not addressed: "Today: N logged" is partially behind the floating tab bar. That
is pre-existing and identical before and after this change, so it's out of scope
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sdMoCETcfDumJBdarLpba