### PR TITLE
Make the top of the habits list the default habit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,17 @@ jobs:
             -project Resistor.xcodeproj \
             -scheme Resistor \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+            -resultBundlePath TestResults.xcresult \
             -quiet
+
+      # `-quiet` prints "** TEST EXECUTE FAILED **" and nothing about *which*
+      # test failed, which makes a red run un-diagnosable without a local repro
+      # that may not reproduce (the UI tests are far slower here than locally).
+      # Name the failures instead of guessing at them.
+      - name: Name the failing tests
+        if: failure()
+        run: |
+          xcrun xcresulttool get test-report summary \
+            --path TestResults.xcresult || true
+          xcrun xcresulttool get test-report tests \
+            --path TestResults.xcresult || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,25 @@ jobs:
       # The Resistor scheme embeds the watchOS app (Embed Watch Content), so the
       # iOS test action also builds the watch app and needs the watchOS simulator
       # runtime present (see CLAUDE.md "Build & Development").
+      #
+      # Only download it when it is actually missing. The macos-15 pool is not
+      # uniform: on images that already ship the runtime `-downloadPlatform`
+      # short-circuits ("watchOS is already downloaded as universal") and passes,
+      # but on the ones that don't it tries to install and dies with "Unable to
+      # connect to simulator" (exit 70) — which took main red on 2026-08-03 for
+      # two pushes running, on a workflow nobody had touched. Listing the runtimes
+      # also spins CoreSimulator up before anything needs it. The final grep is
+      # the assertion: if we somehow reach the build without a watchOS runtime,
+      # fail here with a clear reason rather than inside xcodebuild.
       - name: Install watchOS runtime
-        run: xcodebuild -downloadPlatform watchOS
+        run: |
+          xcrun simctl list runtimes
+          if xcrun simctl list runtimes | grep -q watchOS; then
+            echo "watchOS runtime already installed — skipping download"
+          else
+            xcodebuild -downloadPlatform watchOS
+          fi
+          xcrun simctl list runtimes | grep watchOS
 
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,5 @@ jobs:
       - name: Name the failing tests
         if: failure()
         run: |
-          xcrun xcresulttool get test-report summary \
-            --path TestResults.xcresult || true
-          xcrun xcresulttool get test-report tests \
+          xcrun xcresulttool get test-results summary \
             --path TestResults.xcresult || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,15 +64,34 @@ All four entities use the `@Model` macro. CloudKit compatibility constraints app
 
 Computed: `todayEventsCount`, `thisWeekEventsCount`, `activeEventsCount`.
 
-**Ordering is `Habit.displayOrder`, not `createdAt`.** Every habit list — the Log
-carousel, the Habits screen, the widget's picker, the watch's picker and fallback
-target — sorts by `[sortOrder, createdAt, id]`, so one drag on the Habits screen
-reorders all four. Reorder is edit-mode `.onMove` → `HabitsViewModel.moveHabits`,
+**Ordering is `Habit.displayOrder`, not `createdAt`, and the first habit in it is
+the default habit.** Every habit list — the Log carousel, the Habits screen, the
+widget's picker, the watch's picker and target — sorts by `[sortOrder, createdAt,
+id]`, so one drag on the Habits screen reorders all four *and* changes which habit
+the phone's Log screen and the watch open on. There is no separate default-habit
+setting: `UserSettings.defaultHabitId` was orphaned on 2026-08-03 (issue #60)
+because two user-settable orderings could disagree — the list showed one habit
+first and the app opened on another, and the "Default" badge was the only clue.
+Reorder is edit-mode `.onMove` → `HabitsViewModel.moveHabits`,
 which rewrites the whole active list to a dense 0..n-1 rather than nudging one
 row, so repeated drags can't drift into ties. Until a first drag every habit is 0
 and the `createdAt` tiebreak reproduces the pre-`sortOrder` order exactly — which
 is also why a *new* habit must take `Habit.nextSortOrder(in:)` at creation
-(all three creation sites do), or it would default to 0 and jump to the top.
+(all three creation sites do), or it would default to 0 and jump to the top — and
+now that first place *is* the default habit, that would also silently retarget the
+Log screen and the watch.
+
+**The grip glyph on a habit row is the only hint the order is the user's.** Out of
+edit mode a `List` gives none, and the order now decides what the app opens on, so
+each row carries a `line.3.horizontal` in `.tertiary` when there are 2+ active
+habits — tappable (it turns edit mode on), because a drag on it does nothing until
+the list is editing. It stands down in edit mode so it doesn't double the system's
+own grip. `HabitsView` therefore owns its `isEditing` state and installs
+`\.editMode` itself rather than using `EditButton`: `EditButton` writes to the
+`editMode` the `NavigationStack` installs *below* `HabitsView`'s own environment,
+so the rows could never read it to know when to stand down.
+`testHabitOrderDecidesWhichHabitLogOpensOn` pins both halves — that "Edit" really
+reaches UIKit (the grips exist), and that a drag moves which habit Log opens on.
 
 ### TemptationEvent
 
@@ -152,7 +171,7 @@ in Settings; a place is renamed or removed through the same sheet.
 | Field | Type | Notes |
 |-------|------|-------|
 | `id` | `UUID` | No `@Attribute(.unique)` (CloudKit) |
-| `defaultHabitId` | `UUID?` | Which habit to show first on Log screen |
+| `defaultHabitId` | `UUID?` | **Orphaned.** Nothing reads it — the first habit in `Habit.displayOrder` is the default. Still merged by `mergeDuplicates` |
 | `showContextPrompt` | `Bool` | **Orphaned.** Gated the post-log context sheet, which no longer exists. Nothing reads or sets it — see Sheet Dismissal |
 | `accentColorHex` | `String?` | User-configurable accent color hex. Nil = system blue. |
 | `hasCompletedOnboarding` | `Bool` | Gates onboarding flow |
@@ -233,6 +252,13 @@ from the models:**
 All three are live in the Production CloudKit schema (deployed 2026-07-31), so
 restoring capture for any of them needs UI only — no migration, no schema deploy.
 Don't delete them to "clean up": Production record fields can never be removed.
+
+**`UserSettings.defaultHabitId` joined them on 2026-08-03** (issue #60), for a
+different reason — not an orphaned sheet, a deliberately removed feature. Its
+merge in `mergeDuplicates` is kept rather than deleted, on the same reasoning as
+`showContextPrompt`'s: the field cannot leave Production, and a merge that resolves
+the more plausible of two values costs nothing while a deleted one would have to be
+rewritten if the setting ever comes back.
 
 ### Color Handling
 
@@ -684,8 +710,10 @@ order on the wrist. The pick lives in memory only
 (`WatchLogStore.selectedHabitID`) and resets to the default habit on relaunch,
 exactly like the phone's Log screen; persisting a watch-local override would make
 the two devices disagree about what "the" habit is. Target resolution is pick →
-`UserSettings.defaultHabitId` → first in `Habit.displayOrder`, and a pick that
-gets archived falls back rather than logging to an archived habit.
+first in `Habit.displayOrder`, and a pick that gets archived falls back rather than
+logging to an archived habit. There is no "habit unavailable" state any more: it
+covered a *stored* target that had gone stale, and with `defaultHabitId` orphaned
+nothing is stored — archiving the target just promotes the next habit.
 
 Pager pages are deliberately **not** scrollable — a vertical scroll inside a
 vertically paged `TabView` fights it for the same drag and the same Crown. Only
@@ -864,7 +892,6 @@ Current as of 2026-08-03. Everything previously listed here (#35 icon, #37
 accessibility, #47 widget, #48 haptics, #49 watch) is closed.
 
 - #53 — Log screen: surface multiple habits (scrollable list) to use the empty space
-- #60 — Default habit: make it the top of the reordered list, or drop it
 - #61 — Log screen: habit card content is top-justified, not centered
 - #62 — Log screen: habit pager sits above the card, should be below
 - #63 — Habit editor: expand icon and color choices (icon search)

--- a/Resistor/Models/UserSettings.swift
+++ b/Resistor/Models/UserSettings.swift
@@ -5,6 +5,11 @@ import SwiftUI
 @Model
 final class UserSettings {
     var id: UUID = UUID()
+    /// Orphaned (issue #60): nothing reads this. The default habit is the first
+    /// one in `Habit.displayOrder`, so the drag order the user can already see
+    /// *is* the setting — two orderings could disagree, and did. Kept because a
+    /// Production CloudKit field can never be removed, and still merged below so
+    /// the value survives intact if the setting is ever brought back.
     var defaultHabitId: UUID?
     var showContextPrompt: Bool = true
     var accentColorHex: String?
@@ -64,10 +69,12 @@ extension UserSettings {
         keeper.showContextPrompt = !ordered.contains { !$0.showContextPrompt }
         keeper.accentColorHex = ordered.compactMap(\.accentColorHex).first
 
-        // Prefer a default habit that actually resolves. Falling back to the
-        // first non-nil id rather than to nil matters during a CloudKit import,
-        // when the settings rows can arrive before the habits they point at —
-        // nilling it there would silently discard the user's choice.
+        // Prefer a default habit that actually resolves. Nothing reads this any
+        // more (see the property), but the merge is kept so a revived setting
+        // wouldn't inherit whichever of two rows happened to win. Falling back to
+        // the first non-nil id rather than to nil matters during a CloudKit
+        // import, when the settings rows can arrive before the habits they point
+        // at — nilling it there would silently discard the user's choice.
         let habitIds = Set(habits.map(\.id))
         let candidates = ordered.compactMap(\.defaultHabitId)
         keeper.defaultHabitId = candidates.first { habitIds.contains($0) } ?? candidates.first

--- a/Resistor/Services/UITestSeed.swift
+++ b/Resistor/Services/UITestSeed.swift
@@ -58,7 +58,10 @@ enum UITestSeed {
             context.insert(ContextTag(name: name))
         }
 
-        // Two habits so the Log carousel shows "1 of 2".
+        // Two habits so the Log carousel shows "1 of 2". Sugar is inserted first
+        // and so sorts first in `Habit.displayOrder` (equal sortOrder, earlier
+        // createdAt) — which is what makes it the habit the Log screen opens on,
+        // and therefore the one whose planted pattern is on screen for capture.
         let sugar = Habit(
             name: "Sugar",
             habitDescription: "Reaching for sweets when stressed or bored.",
@@ -73,7 +76,6 @@ enum UITestSeed {
         )
         context.insert(sugar)
         context.insert(phone)
-        settings.defaultHabitId = sugar.id
 
         // A spread of events across the last ~3 weeks so Insights charts and
         // History have real shape: varied outcomes, intensities, contexts, hours.

--- a/Resistor/ViewModels/LogViewModel.swift
+++ b/Resistor/ViewModels/LogViewModel.swift
@@ -42,16 +42,13 @@ final class LogViewModel {
         !habits.isEmpty
     }
 
-    init(modelContext: ModelContext, defaultHabitId: UUID? = nil, locationManager: LocationProviding? = nil) {
+    /// Opens on the *first* habit in `Habit.displayOrder` — index 0. There is no
+    /// separate default-habit setting: the user's drag order on the Habits screen
+    /// is the default, so one list is the only thing to keep in sync.
+    init(modelContext: ModelContext, locationManager: LocationProviding? = nil) {
         self.modelContext = modelContext
         self.locationManager = locationManager
         fetchHabits()
-        if let defaultId = defaultHabitId,
-           let index = habits.firstIndex(where: { $0.id == defaultId }) {
-            selectedHabitIndex = index
-        }
-        // Property observers do not fire during init, so the assignment above
-        // cannot be relied on to have refreshed anything.
         refreshActivePattern()
     }
 

--- a/Resistor/ViewModels/OnboardingViewModel.swift
+++ b/Resistor/ViewModels/OnboardingViewModel.swift
@@ -36,15 +36,12 @@ final class OnboardingViewModel {
         let settingsDescriptor = FetchDescriptor<UserSettings>()
         do {
             let existingSettings = try modelContext.fetch(settingsDescriptor)
+            // No default habit is recorded: the first habit in `displayOrder` is
+            // the default, and this is the only habit there is.
             if let settings = existingSettings.first {
                 settings.hasCompletedOnboarding = true
-                settings.defaultHabitId = newHabit.id
             } else {
-                let newSettings = UserSettings(
-                    defaultHabitId: newHabit.id,
-                    hasCompletedOnboarding: true
-                )
-                modelContext.insert(newSettings)
+                modelContext.insert(UserSettings(hasCompletedOnboarding: true))
             }
 
             try modelContext.save()

--- a/Resistor/Views/HabitsView.swift
+++ b/Resistor/Views/HabitsView.swift
@@ -13,6 +13,10 @@ struct HabitsView: View {
     @State private var showExportSheet = false
     @State private var exportURL: URL?
     @State private var newTagName: String = ""
+    /// Owned rather than read from `\.editMode`, because `EditButton` installs
+    /// that inside the `NavigationStack` — below this view's own environment —
+    /// so the rows could never tell whether the grip hint should stand down.
+    @State private var isEditing = false
 
     /// The user-configured accent color, falling back to the system tint.
     private var accentColor: Color {
@@ -20,6 +24,13 @@ struct HabitsView: View {
             return color
         }
         return UserSettings.defaultAccentColor
+    }
+
+    /// Reordering only means something with two or more habits to order — and
+    /// the first one in that order *is* the habit the Log screen and the watch
+    /// open on, so the drag is the whole default-habit mechanism.
+    private var canReorder: Bool {
+        (viewModel?.activeHabits.count ?? 0) > 1
     }
 
     var body: some View {
@@ -35,9 +46,9 @@ struct HabitsView: View {
             .toolbar {
                 // Drag-to-reorder needs edit mode; only worth offering once
                 // there's more than one active habit to move.
-                if (viewModel?.activeHabits.count ?? 0) > 1 {
+                if canReorder {
                     ToolbarItem(placement: .topBarLeading) {
-                        EditButton()
+                        Button(isEditing ? "Done" : "Edit") { isEditing.toggle() }
                     }
                 }
 
@@ -129,6 +140,7 @@ struct HabitsView: View {
             tipJarSection
         }
         .listStyle(.insetGrouped)
+        .environment(\.editMode, .constant(isEditing ? .active : .inactive))
         .overlay {
             if vm.habits.isEmpty {
                 emptyHabitsView(vm)
@@ -147,22 +159,9 @@ struct HabitsView: View {
 
             // Info
             VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 6) {
-                    Text(habit.name)
-                        .font(.body)
-                        .fontWeight(.medium)
-
-                    if userSettings.first?.defaultHabitId == habit.id {
-                        Text("Default")
-                            .font(.caption2)
-                            .fontWeight(.medium)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(accentColor.opacity(0.15))
-                            .foregroundStyle(accentColor)
-                            .cornerRadius(4)
-                    }
-                }
+                Text(habit.name)
+                    .font(.body)
+                    .fontWeight(.medium)
 
                 if let description = habit.habitDescription, !description.isEmpty {
                     Text(description)
@@ -184,6 +183,23 @@ struct HabitsView: View {
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
             }
+
+            // Reorder affordance. Out of edit mode the list gives no hint that
+            // the order is the user's to set — and the order decides which habit
+            // both the Log screen and the watch open on. In edit mode the system
+            // draws its own grip, so this stands down rather than doubling it.
+            // Tappable so it isn't a dead affordance: a drag here does nothing
+            // until the list is editing.
+            if canReorder && !isEditing && !isArchived {
+                Image(systemName: "line.3.horizontal")
+                    .font(.body)
+                    .foregroundStyle(.tertiary)
+                    .padding(.leading, 8)
+                    .onTapGesture { isEditing = true }
+                    // The row is one combined element; the Edit button is the
+                    // VoiceOver path to reordering.
+                    .accessibilityHidden(true)
+            }
         }
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
@@ -191,18 +207,6 @@ struct HabitsView: View {
         .contentShape(Rectangle())
         .onTapGesture {
             vm.prepareEditHabit(habit)
-        }
-        .contextMenu {
-            if !isArchived {
-                Button {
-                    setDefaultHabit(habit)
-                } label: {
-                    Label(
-                        userSettings.first?.defaultHabitId == habit.id ? "Remove as Default" : "Set as Default",
-                        systemImage: "star"
-                    )
-                }
-            }
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             Button(role: .destructive) {
@@ -227,16 +231,6 @@ struct HabitsView: View {
                 .tint(.orange)
             }
         }
-    }
-
-    private func setDefaultHabit(_ habit: Habit) {
-        guard let settings = userSettings.first else { return }
-        if settings.defaultHabitId == habit.id {
-            settings.defaultHabitId = nil
-        } else {
-            settings.defaultHabitId = habit.id
-        }
-        try? modelContext.save()
     }
 
     @ViewBuilder

--- a/Resistor/Views/LogView.swift
+++ b/Resistor/Views/LogView.swift
@@ -168,7 +168,6 @@ struct LogView: View {
             if viewModel == nil {
                 viewModel = LogViewModel(
                     modelContext: modelContext,
-                    defaultHabitId: userSettings.first?.defaultHabitId,
                     locationManager: locationManager
                 )
             } else {
@@ -185,7 +184,6 @@ struct LogView: View {
             if viewModel == nil {
                 let vm = LogViewModel(
                     modelContext: modelContext,
-                    defaultHabitId: userSettings.first?.defaultHabitId,
                     locationManager: locationManager
                 )
                 vm.prepareHaptics()

--- a/ResistorTests/IntegrationTests.swift
+++ b/ResistorTests/IntegrationTests.swift
@@ -96,13 +96,13 @@ final class IntegrationTests: XCTestCase {
         let created = onboardingVM.createFirstHabit()
         XCTAssertTrue(created)
 
-        // Step 2: Fetch the default habit ID from settings
+        // Step 2: Onboarding is complete; the created habit is the only one, so
+        // it is first in display order and the Log screen opens on it.
         let settings = try context.fetch(FetchDescriptor<UserSettings>())
-        let defaultHabitId = settings.first?.defaultHabitId
-        XCTAssertNotNil(defaultHabitId)
+        XCTAssertTrue(settings.first?.hasCompletedOnboarding == true)
 
         // Step 3: Log a temptation via LogViewModel
-        let logVM = LogViewModel(modelContext: context, defaultHabitId: defaultHabitId)
+        let logVM = LogViewModel(modelContext: context)
         XCTAssertEqual(logVM.habits.count, 1)
         XCTAssertEqual(logVM.selectedHabit?.name, "Smoking")
 
@@ -187,7 +187,10 @@ final class IntegrationTests: XCTestCase {
         context.insert(habit3)
         try context.save()
 
-        let logVM = LogViewModel(modelContext: context, defaultHabitId: habit2.id)
+        let logVM = LogViewModel(modelContext: context)
+        // The carousel opens on the first habit; select the second explicitly,
+        // which is what a swipe on the Log screen does.
+        logVM.selectedHabitIndex = try XCTUnwrap(logVM.habits.firstIndex { $0.id == habit2.id })
         XCTAssertEqual(logVM.selectedHabit?.name, "Drinking")
 
         logVM.logTemptation()

--- a/ResistorTests/LogViewModelTests.swift
+++ b/ResistorTests/LogViewModelTests.swift
@@ -33,27 +33,34 @@ final class LogViewModelTests: XCTestCase {
         XCTAssertEqual(vm.habits.first?.name, "Active")
     }
 
-    func testInitWithDefaultHabitIdSelectsCorrectHabit() throws {
+    /// The Log screen opens on the first habit in `Habit.displayOrder` — there is
+    /// no separate default-habit setting, the user's drag order *is* the default.
+    func testInitOpensOnFirstHabitInDisplayOrder() throws {
         let habit1 = TestHelpers.makeHabit(name: "First", createdAt: Date.distantPast)
         let habit2 = TestHelpers.makeHabit(name: "Second", createdAt: Date())
         context.insert(habit1)
         context.insert(habit2)
         try context.save()
 
-        let vm = LogViewModel(modelContext: context, defaultHabitId: habit2.id)
-
-        XCTAssertEqual(vm.selectedHabit?.name, "Second")
+        XCTAssertEqual(LogViewModel(modelContext: context).selectedHabit?.name, "First")
     }
 
-    func testInitWithInvalidDefaultHabitIdDefaultsToFirst() throws {
-        let habit = TestHelpers.makeHabit(name: "Only")
-        context.insert(habit)
+    /// A drag on the Habits screen rewrites `sortOrder`, and that moves which
+    /// habit the Log screen opens on — the whole point of dropping the setting.
+    func testReorderingChangesWhichHabitOpens() throws {
+        let habit1 = TestHelpers.makeHabit(name: "First", createdAt: Date.distantPast)
+        let habit2 = TestHelpers.makeHabit(name: "Second", createdAt: Date())
+        context.insert(habit1)
+        context.insert(habit2)
         try context.save()
 
-        let vm = LogViewModel(modelContext: context, defaultHabitId: UUID())
+        habit2.sortOrder = 0
+        habit1.sortOrder = 1
+        try context.save()
 
+        let vm = LogViewModel(modelContext: context)
         XCTAssertEqual(vm.selectedHabitIndex, 0)
-        XCTAssertEqual(vm.selectedHabit?.name, "Only")
+        XCTAssertEqual(vm.selectedHabit?.name, "Second")
     }
 
     func testInitWithNoHabits() throws {

--- a/ResistorTests/OnboardingViewModelTests.swift
+++ b/ResistorTests/OnboardingViewModelTests.swift
@@ -67,16 +67,18 @@ final class OnboardingViewModelTests: XCTestCase {
         XCTAssertTrue(settings.first!.hasCompletedOnboarding)
     }
 
-    func testCreateFirstHabitSetsDefaultHabitId() throws {
+    /// Onboarding records no default habit — the habit it creates is the only one
+    /// and therefore already first in `Habit.displayOrder`, which is what the Log
+    /// screen opens on.
+    func testCreateFirstHabitRecordsNoDefaultHabitId() throws {
         let vm = OnboardingViewModel(modelContext: context)
         vm.habitName = "Test"
 
         _ = vm.createFirstHabit()
 
-        let habits = try context.fetch(FetchDescriptor<Habit>())
         let settings = try context.fetch(FetchDescriptor<UserSettings>())
-
-        XCTAssertEqual(settings.first?.defaultHabitId, habits.first?.id)
+        XCTAssertNil(settings.first?.defaultHabitId)
+        XCTAssertEqual(LogViewModel(modelContext: context).selectedHabit?.name, "Test")
     }
 
     func testCreateFirstHabitConvertsEmptyDescriptionToNil() throws {

--- a/ResistorTests/WatchLogStoreLogicTests.swift
+++ b/ResistorTests/WatchLogStoreLogicTests.swift
@@ -47,34 +47,18 @@ final class WatchLogStoreLogicTests: XCTestCase {
         return (try? context.fetch(descriptor)) ?? []
     }
 
-    private func defaultHabitId() -> UUID? {
-        let descriptor = FetchDescriptor<UserSettings>()
-        return (try? context.fetch(descriptor))?.first?.defaultHabitId
-    }
-
     /// The habit picked on the watch this session, mirroring
     /// `WatchLogStore.selectedHabitID` (in-memory, cleared on relaunch).
     private var selectedHabitID: UUID?
 
-    /// Verbatim copy of `WatchLogStore.resolveTargetHabit(in:)`.
+    /// Verbatim copy of `WatchLogStore.resolveTargetHabit(among:)`.
     private func resolveTargetHabit() -> Habit? {
         let active = activeHabits()
-        guard !active.isEmpty else { return nil }
         if let selectedHabitID,
            let picked = active.first(where: { $0.id == selectedHabitID }) {
             return picked
         }
-        if let defaultID = defaultHabitId(),
-           let match = active.first(where: { $0.id == defaultID }) {
-            return match
-        }
         return active.first
-    }
-
-    /// Verbatim copy of `WatchLogStore.hasConfiguredButMissingDefault(in:)`.
-    private func hasConfiguredButMissingDefault() -> Bool {
-        guard let defaultID = defaultHabitId() else { return false }
-        return !activeHabits().contains { $0.id == defaultID }
     }
 
     /// Verbatim copy of `WatchLogStore.todayResistedCount(for:in:)`.
@@ -87,40 +71,20 @@ final class WatchLogStoreLogicTests: XCTestCase {
         }.count
     }
 
-    private func makeSettings(defaultHabitId: UUID?) -> UserSettings {
-        let s = UserSettings()
-        s.defaultHabitId = defaultHabitId
-        return s
-    }
+    // MARK: - UC-WATCH-7: target resolution (first in display order)
 
-    // MARK: - UC-WATCH-7: target resolution (default → deterministic first)
-
-    /// With a valid configured default that points at a live non-archived habit,
-    /// that habit is the target even when it isn't first in createdAt order.
-    func testResolvePrefersConfiguredDefault() throws {
-        let first = TestHelpers.makeHabit(name: "First", createdAt: Date(timeIntervalSince1970: 100))
-        let second = TestHelpers.makeHabit(name: "Second", createdAt: Date(timeIntervalSince1970: 200))
-        context.insert(first)
-        context.insert(second)
-        context.insert(makeSettings(defaultHabitId: second.id))
-        try context.save()
-
-        let target = try XCTUnwrap(resolveTargetHabit())
-        XCTAssertEqual(target.id, second.id, "configured default wins over createdAt order")
-    }
-
-    /// With no default configured, resolution falls back to the deterministic
-    /// first non-archived habit (earliest createdAt).
-    func testResolveFallsBackToFirstNonArchivedByCreatedAt() throws {
+    /// The target is the first non-archived habit in display order — which, with
+    /// no drag yet, is the earliest `createdAt`. There is no default-habit
+    /// setting to prefer over it; the phone's drag order *is* the default.
+    func testResolveTargetsFirstNonArchivedInDisplayOrder() throws {
         let later = TestHelpers.makeHabit(name: "Later", createdAt: Date(timeIntervalSince1970: 300))
         let earlier = TestHelpers.makeHabit(name: "Earlier", createdAt: Date(timeIntervalSince1970: 100))
         context.insert(later)
         context.insert(earlier)
-        // No UserSettings at all.
         try context.save()
 
         let target = try XCTUnwrap(resolveTargetHabit())
-        XCTAssertEqual(target.id, earlier.id, "earliest createdAt is the deterministic fallback")
+        XCTAssertEqual(target.id, earlier.id, "earliest createdAt is first in display order")
     }
 
     /// Resolution is stable/deterministic across repeated reads (no random order).
@@ -137,18 +101,17 @@ final class WatchLogStoreLogicTests: XCTestCase {
         }
     }
 
-    /// An archived default is NOT the target; resolution falls back to the first
-    /// live non-archived habit instead (never logs to an archived habit).
-    func testArchivedDefaultFallsBackToLiveHabit() throws {
-        let archivedDefault = TestHelpers.makeHabit(name: "Archived", isArchived: true, createdAt: Date(timeIntervalSince1970: 100))
+    /// An archived habit is never the target even when it would sort first — the
+    /// watch skips to the first *live* habit rather than logging to an archive.
+    func testArchivedFirstHabitIsSkipped() throws {
+        let archived = TestHelpers.makeHabit(name: "Archived", isArchived: true, createdAt: Date(timeIntervalSince1970: 100))
         let live = TestHelpers.makeHabit(name: "Live", createdAt: Date(timeIntervalSince1970: 200))
-        context.insert(archivedDefault)
+        context.insert(archived)
         context.insert(live)
-        context.insert(makeSettings(defaultHabitId: archivedDefault.id))
         try context.save()
 
         let target = try XCTUnwrap(resolveTargetHabit())
-        XCTAssertEqual(target.id, live.id, "archived default is skipped; live habit is target")
+        XCTAssertEqual(target.id, live.id, "archived habit is skipped; live habit is target")
         XCTAssertFalse(target.isArchived)
     }
 
@@ -166,18 +129,16 @@ final class WatchLogStoreLogicTests: XCTestCase {
 
     // MARK: - Watch habit switching
 
-    /// A habit picked on the watch beats the configured default — the whole
-    /// point of the picker is logging against something other than the default
-    /// without reaching for the phone.
-    func testSelectionBeatsConfiguredDefault() throws {
-        let defaultHabit = TestHelpers.makeHabit(name: "Default", createdAt: Date(timeIntervalSince1970: 100))
+    /// A habit picked on the watch beats first-in-order — the whole point of the
+    /// pager is logging against something else without reaching for the phone.
+    func testSelectionBeatsFirstInDisplayOrder() throws {
+        let first = TestHelpers.makeHabit(name: "First", createdAt: Date(timeIntervalSince1970: 100))
         let other = TestHelpers.makeHabit(name: "Other", createdAt: Date(timeIntervalSince1970: 200))
-        context.insert(defaultHabit)
+        context.insert(first)
         context.insert(other)
-        context.insert(makeSettings(defaultHabitId: defaultHabit.id))
         try context.save()
 
-        XCTAssertEqual(resolveTargetHabit()?.id, defaultHabit.id, "default before any pick")
+        XCTAssertEqual(resolveTargetHabit()?.id, first.id, "first in order before any pick")
 
         selectedHabitID = other.id
         XCTAssertEqual(resolveTargetHabit()?.id, other.id, "watch pick wins")
@@ -185,12 +146,11 @@ final class WatchLogStoreLogicTests: XCTestCase {
 
     /// A picked habit that is later archived stops being the target — the watch
     /// falls back rather than logging to an archived habit.
-    func testArchivedSelectionFallsBackToDefault() throws {
-        let defaultHabit = TestHelpers.makeHabit(name: "Default", createdAt: Date(timeIntervalSince1970: 100))
+    func testArchivedSelectionFallsBackToFirstInDisplayOrder() throws {
+        let first = TestHelpers.makeHabit(name: "First", createdAt: Date(timeIntervalSince1970: 100))
         let picked = TestHelpers.makeHabit(name: "Picked", createdAt: Date(timeIntervalSince1970: 200))
-        context.insert(defaultHabit)
+        context.insert(first)
         context.insert(picked)
-        context.insert(makeSettings(defaultHabitId: defaultHabit.id))
         try context.save()
 
         selectedHabitID = picked.id
@@ -199,7 +159,7 @@ final class WatchLogStoreLogicTests: XCTestCase {
         picked.isArchived = true
         try context.save()
 
-        XCTAssertEqual(resolveTargetHabit()?.id, defaultHabit.id,
+        XCTAssertEqual(resolveTargetHabit()?.id, first.id,
                        "archived pick is dropped, not logged against")
     }
 
@@ -228,11 +188,11 @@ final class WatchLogStoreLogicTests: XCTestCase {
     // MARK: - UC-WATCH-5: non-loggable states resolve, never a false target
 
     /// No habits at all → no target resolves → state (d) noHabit (the View shows
-    /// the non-loggable branch and a tap cannot log).
+    /// the non-loggable branch and a tap cannot log). With no default-habit
+    /// setting, this is the *only* way resolution can fail.
     func testNoHabitsResolvesToNoTarget() throws {
         // Empty store.
         XCTAssertNil(resolveTargetHabit(), "no habits → no resolvable target")
-        XCTAssertFalse(hasConfiguredButMissingDefault(), "no default configured → state (d), not (e)")
     }
 
     /// All habits archived → no target resolves (UC-WATCH-5: habit unavailable,
@@ -243,33 +203,6 @@ final class WatchLogStoreLogicTests: XCTestCase {
         try context.save()
 
         XCTAssertNil(resolveTargetHabit(), "all archived → no resolvable target")
-    }
-
-    /// A configured default that is now gone with NO fallback distinguishes state
-    /// (e) habitUnavailable from (d) noHabit.
-    func testConfiguredDefaultMissingWithNoFallbackIsHabitUnavailable() throws {
-        let goneID = UUID() // never inserted
-        context.insert(makeSettings(defaultHabitId: goneID))
-        try context.save()
-
-        XCTAssertNil(resolveTargetHabit(), "default points nowhere and no other habit exists")
-        XCTAssertTrue(hasConfiguredButMissingDefault(),
-                      "configured-but-missing default → state (e) habitUnavailable, not (d)")
-    }
-
-    /// A configured default that was archived, with another live habit present,
-    /// resolves to the live habit (does NOT become habitUnavailable) — matches the
-    /// watch's resolve-then-fallback ordering.
-    func testArchivedDefaultWithFallbackIsLoggableNotUnavailable() throws {
-        let archived = TestHelpers.makeHabit(name: "Archived", isArchived: true, createdAt: Date(timeIntervalSince1970: 100))
-        let live = TestHelpers.makeHabit(name: "Live", createdAt: Date(timeIntervalSince1970: 200))
-        context.insert(archived)
-        context.insert(live)
-        context.insert(makeSettings(defaultHabitId: archived.id))
-        try context.save()
-
-        XCTAssertNotNil(resolveTargetHabit(), "a live fallback exists → loggable, not unavailable")
-        XCTAssertEqual(resolveTargetHabit()?.id, live.id)
     }
 
     // MARK: - UC-WATCH-3: today's resisted count (calendar-day, resisted-only)

--- a/ResistorUITests/SnapshotTests.swift
+++ b/ResistorUITests/SnapshotTests.swift
@@ -347,6 +347,41 @@ final class SnapshotTests: XCTestCase {
         XCTAssertEqual(bare.frame.height, describedSize.height, accuracy: 0.5)
     }
 
+    /// The habit order *is* the default-habit setting: whatever sits first in the
+    /// Habits list is what the Log screen opens on. Pins both halves of that —
+    /// that "Edit" really puts the list into edit mode (the reorder grips are
+    /// drawn by UIKit off an `editMode` this view owns itself, rather than the one
+    /// `EditButton` installs inside the `NavigationStack`, so a broken binding
+    /// would show grips and reorder nothing), and that dragging actually moves
+    /// which habit the Log screen opens on.
+    func testHabitOrderDecidesWhichHabitLogOpensOn() {
+        let app = XCUIApplication()
+        app.launchArguments += ["-uiTestMode"]
+        app.launch()
+
+        // Seeded order is Sugar, then Doomscrolling.
+        XCTAssertTrue(app.buttons["Log temptation for Sugar"].waitForExistence(timeout: 5),
+                      "Log screen should open on the first habit")
+
+        app.buttons["Habits"].tap()
+        XCTAssertTrue(app.navigationBars["Habits"].waitForExistence(timeout: 5))
+        app.navigationBars["Habits"].buttons["Edit"].tap()
+
+        // UIKit draws these off the edit mode this view owns; they exist only if
+        // the binding reached the List.
+        let sugarGrip = app.buttons["Reorder Sugar"]
+        let doomGrip = app.buttons["Reorder Doomscrolling"]
+        XCTAssertTrue(sugarGrip.exists, "no reorder grip — edit mode did not activate")
+        XCTAssertTrue(doomGrip.exists, "no reorder grip — edit mode did not activate")
+
+        doomGrip.press(forDuration: 0.6, thenDragTo: sugarGrip)
+        app.navigationBars["Habits"].buttons["Done"].tap()
+
+        app.buttons["Log"].tap()
+        XCTAssertTrue(app.buttons["Log temptation for Doomscrolling"].waitForExistence(timeout: 5),
+                      "after reordering, Log opens on the new first habit")
+    }
+
     private func snapshot(_ app: XCUIApplication, name: String) {
         let screenshot = XCUIScreen.main.screenshot()
         let attachment = XCTAttachment(screenshot: screenshot)

--- a/ResistorUITests/SnapshotTests.swift
+++ b/ResistorUITests/SnapshotTests.swift
@@ -368,17 +368,21 @@ final class SnapshotTests: XCTestCase {
         app.navigationBars["Habits"].buttons["Edit"].tap()
 
         // UIKit draws these off the edit mode this view owns; they exist only if
-        // the binding reached the List.
+        // the binding reached the List. Waited for rather than checked with
+        // `.exists`, which samples once and so races the rows' layout on a runner
+        // slower than a local simulator.
         let sugarGrip = app.buttons["Reorder Sugar"]
         let doomGrip = app.buttons["Reorder Doomscrolling"]
-        XCTAssertTrue(sugarGrip.exists, "no reorder grip — edit mode did not activate")
-        XCTAssertTrue(doomGrip.exists, "no reorder grip — edit mode did not activate")
+        XCTAssertTrue(sugarGrip.waitForExistence(timeout: 5),
+                      "no reorder grip — edit mode did not activate")
+        XCTAssertTrue(doomGrip.waitForExistence(timeout: 5),
+                      "no reorder grip — edit mode did not activate")
 
         doomGrip.press(forDuration: 0.6, thenDragTo: sugarGrip)
         app.navigationBars["Habits"].buttons["Done"].tap()
 
         app.buttons["Log"].tap()
-        XCTAssertTrue(app.buttons["Log temptation for Doomscrolling"].waitForExistence(timeout: 5),
+        XCTAssertTrue(app.buttons["Log temptation for Doomscrolling"].waitForExistence(timeout: 10),
                       "after reordering, Log opens on the new first habit")
     }
 

--- a/ResistorWatch/WatchLogStore.swift
+++ b/ResistorWatch/WatchLogStore.swift
@@ -4,9 +4,12 @@ import SwiftData
 import Observation
 
 /// The resolved render state for the watch Quick-Log screen. Mirrors the UX
-/// spec's states (a)/(d)/(e)/(f) — a loggable target with a known count, a
-/// loggable target whose count read failed, no habit at all, or a configured
-/// default that is no longer valid with no fallback.
+/// spec's states (a)/(d)/(f) — a loggable target with a known count, a loggable
+/// target whose count read failed, or no habit at all.
+///
+/// There is no "configured default is gone" state: with the default-habit
+/// setting removed, the target is simply the first non-archived habit in display
+/// order, so "no habit to log" is the only way resolution can fail.
 enum WatchLogState: Equatable {
     /// (a)/(f) Loggable. A valid target habit is resolved and named. `count` is
     /// `nil` when the count read failed (render "Count unavailable", never a
@@ -14,15 +17,12 @@ enum WatchLogState: Equatable {
     case loggable(habitID: UUID, name: String, colorHex: String?, iconName: String?, count: Int?)
     /// (d) No habit exists to log against.
     case noHabit
-    /// (e) A default was set but is now archived/deleted and no other
-    /// non-archived habit exists to fall back to.
-    case habitUnavailable
 }
 
 /// The single data path for the watch Quick-Log screen. Owns the watch-side
-/// `ModelContext`, resolves the target habit (default → else sole/first
-/// non-archived habit, deterministic order), reads today's resisted count, and
-/// performs the log via the shared `TemptationLogger`.
+/// `ModelContext`, resolves the target habit (watch pick → else first
+/// non-archived habit in the phone's display order), reads today's resisted
+/// count, and performs the log via the shared `TemptationLogger`.
 ///
 /// Kept as a small reusable provider (not inlined in the View) so a future
 /// complication is just a new presentation over the same `state` /
@@ -110,15 +110,8 @@ final class WatchLogStore {
         let active = activeHabits(in: context)
         habitOptions = active
 
-        guard let habit = resolveTargetHabit(among: active, in: context) else {
-            // Distinguish (e) from (d): if a default was configured but is gone
-            // and there's truly nothing to fall back to, it's "habit
-            // unavailable"; otherwise there simply is no habit yet.
-            if let defaultID = defaultHabitId(in: context), !active.contains(where: { $0.id == defaultID }) {
-                state = .habitUnavailable
-            } else {
-                state = .noHabit
-            }
+        guard let habit = resolveTargetHabit(among: active) else {
+            state = .noHabit
             return
         }
 
@@ -198,22 +191,17 @@ final class WatchLogStore {
     // MARK: - Target resolution
 
     /// Resolves the target habit: whatever was picked on the watch this session
-    /// if it's still live, else `UserSettings.defaultHabitId` if that points at a
-    /// live non-archived habit, else the first non-archived habit in display
-    /// order. Returns `nil` only when no non-archived habit exists at all.
-    private func resolveTargetHabit(among active: [Habit], in context: ModelContext) -> Habit? {
-        guard !active.isEmpty else { return nil }
-
+    /// if it's still live, else the first non-archived habit in the phone's
+    /// display order. Returns `nil` only when no non-archived habit exists.
+    ///
+    /// First-in-display-order *is* the default habit — the user sets it by
+    /// dragging on the phone's Habits screen, so the watch and the phone's Log
+    /// screen open on the same habit without a second setting to keep in sync.
+    private func resolveTargetHabit(among active: [Habit]) -> Habit? {
         if let selectedHabitID,
            let picked = active.first(where: { $0.id == selectedHabitID }) {
             return picked
         }
-
-        if let defaultID = defaultHabitId(in: context),
-           let match = active.first(where: { $0.id == defaultID }) {
-            return match
-        }
-        // Deterministic fallback so the watch always names a stable target.
         return active.first
     }
 
@@ -225,11 +213,6 @@ final class WatchLogStore {
             sortBy: Habit.displayOrder
         )
         return (try? context.fetch(descriptor)) ?? []
-    }
-
-    private func defaultHabitId(in context: ModelContext) -> UUID? {
-        let descriptor = FetchDescriptor<UserSettings>()
-        return (try? context.fetch(descriptor))?.first?.defaultHabitId
     }
 
     // MARK: - Count

--- a/ResistorWatch/WatchLogView.swift
+++ b/ResistorWatch/WatchLogView.swift
@@ -151,14 +151,6 @@ struct WatchLogView: View {
                         subtitle: "Add a habit on your phone"
                     )
                 }
-            case .habitUnavailable:
-                page {
-                    nonLoggable(
-                        symbol: "exclamationmark.triangle",
-                        title: "Habit unavailable",
-                        subtitle: "Set a default habit on your phone"
-                    )
-                }
             }
         } else {
             // Pre-init frame; render nothing rather than a flash of wrong state.

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,20 +1,28 @@
-Log screen: two layout corrections.
+The default habit is now just the top of your habits list.
 
-The habit pager (arrows and dots) has moved from above the habit card to below
-it, under the "Tap or hold to log" line — where iOS normally puts page dots.
+The "Default" badge is gone, and so is "Set as Default" in the row's context
+menu. Instead, whichever habit sits first on the Habits screen is the one the
+Log screen and the Apple Watch open on. You change it by dragging.
 
-The card's icon and name were sitting high, with empty space under them, on any
-habit with no description. They're now centred in the card.
+Each habit row now shows a small grip icon on the right when you have two or
+more habits, so it's visible that the order is yours to set. Tapping it turns on
+edit mode; the toolbar "Edit" button still does the same thing.
+
+Whatever you had set as your default before is not carried over — the habit that
+opens is now purely a matter of list order, so check the order is what you want.
 
 Worth checking:
 
-- With more than one habit, the pager reads as belonging to the card below it
-  rather than to whatever is above it. Arrows and dots still work.
-- Make a habit with no description at all. Its icon and name should sit in the
-  middle of the card, not near the top.
-- Swipe between a habit that has a description and one that doesn't. The card
-  must not change size or jump mid-swipe — that's the thing most at risk here.
-- Nothing below the card moved: context chips and "Today: N logged" should sit
-  exactly where they did before.
-
-Nothing changed on the Apple Watch in this build.
+- With two or more habits, drag one to the top on the Habits screen, then go to
+  the Log tab. It should open on the habit you just moved to the top.
+- Same check on the Apple Watch: after the phone syncs, the watch should open on
+  the same habit the phone does. This is the part most at risk.
+- With exactly one habit, the grip icon and the "Edit" button should both be
+  absent — there's nothing to reorder.
+- The grip icon should disappear while you're in edit mode (the system draws its
+  own there). You shouldn't ever see two grips on one row.
+- Tapping a habit row still opens its editor, in and out of edit mode.
+- Archive the top habit. Log and the watch should move to the next one down
+  rather than showing an error.
+- VoiceOver: the grip is deliberately skipped; reordering is reachable through
+  the "Edit" button.

--- a/docs/design.md
+++ b/docs/design.md
@@ -312,14 +312,15 @@ Fixed product decisions for v1 (the watch ships deliberately small):
    CloudKit. Once synced, it appears in the phone's Insights and History like any
    other event.
 
-**Which habit does the watch log to?** v1 logs to the user's **default habit**
-(`UserSettings.defaultHabitId`), falling back to the single habit if only one
-exists. On-watch habit *switching* was **Later** here and has since shipped as a
-vertical pager (Screens → WATCH → Habit Paging); the default habit is now the
-page the watch *opens* on. If the user has multiple
-habits and no default set, the watch logs to a deterministic first habit and
-names it on screen so the target is never ambiguous (it never logs to an
-unnamed/"current" habit silently).
+**Which habit does the watch log to?** The **first non-archived habit in
+`Habit.displayOrder`** — i.e. the top of the user's own drag order on the phone's
+Habits screen. There is no separate default-habit setting: `defaultHabitId` was
+removed as a reader in favour of the order the user can already see and change,
+so the phone's Log screen and the watch open on the same habit with one list to
+keep in sync. On-watch habit *switching* was **Later** here and has since shipped
+as a vertical pager (Screens → WATCH → Habit Paging); first-in-order is the page
+the watch *opens* on. The target is always named on screen, so it is never
+ambiguous (it never logs to an unnamed/"current" habit silently).
 
 Edge cases:
 - **Phone not present / not reachable.** The watch logs independently into its
@@ -331,12 +332,12 @@ Edge cases:
 - **No habits configured.** The watch cannot create a habit (habit creation stays
   on the phone). It shows a neutral non-loggable state directing the user to add a
   habit on the phone; a tap does not write a stray event.
-- **Default habit archived or deleted.** The watch's target no longer resolves to
-  a live, non-archived habit; it shows a non-loggable "habit unavailable" state
-  (parallel to the widget's needs-reconfiguration state) and a tap does not log.
-  If another non-archived habit exists, v1 may fall back to the deterministic
-  first habit (named on screen); choosing fall-back vs. blocking is a ux-designer
-  call so long as the watch never logs to an unnamed target.
+- **Target habit archived or deleted.** ~~"Habit unavailable" state.~~ **Gone
+  with the default-habit setting.** The target is whatever sits first in display
+  order, so archiving it just promotes the next habit — there is no such thing as
+  a configured target that no longer resolves. Only "no habits at all" remains,
+  which is the state above. A watch-side pick that gets archived falls back the
+  same way, never logging to an archived habit.
 - **Local store unreadable on watch.** If the watch's local SwiftData store
   cannot be opened (e.g. first launch mid-sync), the count is unknown; the watch
   shows a count-unavailable state. As with the widget, a tap must not silently
@@ -1202,7 +1203,7 @@ emoji.
 - Active habits list with swipe actions (archive, delete)
 - Archived habits list with swipe actions (unarchive, delete)
 - Add/edit habit form (name, description, color, icon, preview)
-- Context menu: set/remove as default habit
+- Drag-to-reorder the active list; the top habit is the one Log and the watch open on
 - Settings: context prompt toggle, accent color picker
 - Data: export, delete all data
 - (Future: tip jar)
@@ -1727,9 +1728,8 @@ CloudKit container the phone uses (`iCloud.com.resistor.app`); parity comes from
 Fixed product decisions (not open for design re-litigation):
 - **Single-screen, single-tap.** One large log control for one habit. A tap fires
   the shared logger; no outcome/intensity/context capture on the watch.
-- **Opens on the default habit.** The watch targets `UserSettings.defaultHabitId`
-  (falling back to the sole habit, then a deterministic first habit, always named
-  on screen).
+- **Opens on the first habit in `Habit.displayOrder`** — the top of the user's
+  drag order on the phone, always named on screen. Not a separate setting.
 - **Taptic confirmation + brief neutral acknowledgment.** The success haptic is
   the primary confirmation; any on-screen acknowledgment is clinical (e.g.
   "Logged"), never celebratory.
@@ -1848,8 +1848,7 @@ sizing are a ux-designer/implementer detail for the small watch canvas.
 | Post-log acknowledgment | `Logged` (matches the phone banner's State-1 status word; neutral, not celebratory) |
 | No-habit state — primary | `No habit to log` |
 | No-habit state — secondary | `Add a habit on your phone` |
-| Habit-unavailable state — primary | `Habit unavailable` |
-| Habit-unavailable state — secondary | `Set a default habit on your phone` |
+| ~~Habit-unavailable state~~ | **Removed** with the default-habit setting — no configured target can go stale, so the state is unreachable |
 | Count-unavailable state | `Count unavailable` |
 | Forbidden | No "Great job", "Streak", "You resisted!", success/celebration copy, or emoji anywhere on the watch |
 
@@ -2084,24 +2083,15 @@ tap does nothing (no button, no log, no haptic).
 - No habit-color anywhere (there is no habit). The de-emphasized secondary glyph
   signals non-loggable.
 
-###### State (e): Habit unavailable (default/target habit archived or deleted)
+###### State (e): Habit unavailable — **removed**
 
-The stored target no longer resolves to a live, non-archived habit, **and** the
-watch has no other non-archived habit to fall back to (if one *does* exist, v1
-falls back to the deterministic first habit and renders state (a) with that
-habit's name — it never silently blocks when a valid target exists; it also never
-logs to an unnamed target). When there is genuinely no valid target:
-
-- **Replace the button** with `Image(systemName: "exclamationmark.triangle")`,
-  `.font(.system(size: 36))`, `.foregroundStyle(.secondary)` (**not** `.red` — this
-  is a setup condition, not a destructive error; `.secondary` keeps it calm and
-  clinical, matching the widget's needs-reconfiguration glyph). Not a `Button`.
-- Primary text: `Text("Habit unavailable")`, `.font(.headline)`,
-  `.foregroundStyle(.primary)`, centered, `.lineLimit(2)`.
-- Secondary text: `Text("Set a default habit on your phone")`, `.font(.footnote)`,
-  `.foregroundStyle(.secondary)`, centered, `.lineLimit(2)`.
-- Do **not** show the dead habit's name or color — the binding is stale; showing
-  it would imply it still logs there.
+This state existed to cover a *stored* target (`UserSettings.defaultHabitId`) that
+no longer resolved to a live habit. With the default-habit setting dropped, the
+target is simply the first non-archived habit in `Habit.displayOrder`, so
+archiving or deleting it promotes the next one — there is nothing left that can go
+stale. `WatchLogState.habitUnavailable` and its view branch are gone; state (d)
+"no habit to log" is the only non-loggable case. Don't reintroduce it without a
+stored target to justify it.
 
 ###### State (f): Count unavailable (local store unreadable)
 
@@ -2242,11 +2232,11 @@ mid-sync), so today's count is unknown. The watch **must never show a false `0`*
     VoiceOver user hears confirmation without seeing the fade. (watchOS supports
     `UIAccessibility.post`; unlike the widget extension, the watch app *can* post
     announcements.)
-- **VoiceOver — non-loggable states (d, e):** the whole screen is **one combined
+- **VoiceOver — non-loggable state (d):** the whole screen is **one combined
   element** (`.accessibilityElement(children: .combine)`), **no `.isButton`
   trait**, so a non-visual user is never told they can log when they cannot.
   - State (d) label: `"No habit to log. Add a habit on your phone."`
-  - State (e) label: `"Habit unavailable. Set a default habit on your phone."`
+  - (State (e) removed — see above.)
   - No "logs" hint (a tap does nothing). No on-activate log.
 - **VoiceOver — count line** when read separately (state a): the count is folded
   into the button's combined label (above), so it is **not** a second focus stop —
@@ -2624,8 +2614,8 @@ User-defined. Managed via the `ContextTag` SwiftData model. Users create and del
 - Title: "Habits"; toolbar add button VoiceOver "Add Habit"
 - Empty: "No habits yet" / "Create a habit to start tracking your temptations." / "Add Habit"
 - Section headers: "Active Habits", "Archived", "Settings", "Context Tags", "Data", "Tip Jar"
-- Habit row: "Default" badge; "{n}" + "logged"
-- Row actions: "Delete", "Archive", "Unarchive"; "Set as Default" / "Remove as Default"
+- Habit row: "{n}" + "logged"; a `line.3.horizontal` grip glyph when there are 2+ active habits. **No "Default" badge** — the top of the list *is* the default
+- Row actions: "Delete", "Archive", "Unarchive"; toolbar "Edit" / "Done" for drag-to-reorder
 - Delete habit alert: "Delete Habit?" / "This will permanently delete this habit and all its logged events. This cannot be undone." / "Cancel" / "Delete"
 - Settings: "Accent Color". **No context-prompt toggle** — `UserSettings.showContextPrompt` still exists on the model and is merged by `mergeDuplicates`, but nothing reads or sets it (context is now inline chips on the Log screen)
 - Context Tags: tags listed by name, swipe to delete; new-tag field placeholder "Add a tag"
@@ -2760,7 +2750,7 @@ Neither target exists yet.
 - Next/previous wrapping
 - Out-of-bounds index handling
 - Fetching excludes archived habits
-- Default habit ID
+- Opens on the first habit in `Habit.displayOrder`; a reorder moves it
 
 **P3: Insights Calculations**
 - Total events in range (week, month)
@@ -3139,12 +3129,12 @@ configurable single-habit model is the chosen design).
 
 **Watch Quick-Log (watchOS App)** — A standalone watchOS app whose single job is
 the fastest possible one-tap log of a resisted temptation from the wrist, no phone
-needed. Logs to the user's default habit, shows today's resisted count at rest,
+needed. Logs to the first habit in display order, shows today's resisted count at rest,
 confirms with a Taptic Engine haptic. Reuses the shared
 `TemptationLogger.logResisted(...)`; data parity with the phone comes from
 **CloudKit sync of the same container, not the App Group** (App Groups do not
 bridge separate devices). Full brief: User Flows → Flow 6 and Screens → WATCH.
-**Scope this pass: single-screen, single-tap log to the default habit + today's
+**Scope this pass: single-screen, single-tap log to the first habit in order + today's
 count + success haptic + CloudKit-synced store.** **Out/Later:** a complication,
 on-watch habit switching, outcome/intensity capture on the watch, undo/correction
 on the watch, and a fully phone-less independent install (App Store watch-only
@@ -3302,7 +3292,7 @@ Summary of all design decisions made during the design phase.
 | Intensity default | Nil (not 3) | Nil = didn't engage, preserves data integrity |
 | Banner timing | Immediately on log (superseded: "after all sheets dismiss"), 5s with undo | Undo prevents accidental logs. The original rule existed because the banner was hidden behind the outcome/context sheets; those were removed, so nothing now sits between the tap and the banner |
 | Outcome/context sheets | Removed | Replaced by default-to-resisted + banner correction and pre-log context chips. Casualties: `intensity` and `note` lost their only capture UI, and `UserSettings.showContextPrompt` lost its only reader |
-| Default habit | User-settable via context menu | Core for fast logging |
+| Default habit | **The first habit in `Habit.displayOrder`** — set by dragging on the Habits screen, not by a separate setting (superseded: "user-settable via context menu" + a "Default" badge) | Two orderings the user could set (a drag order *and* a default flag) meant the list could show one habit first and open on another. One list, one meaning, one thing to discover — and `UserSettings.defaultHabitId` joins `showContextPrompt` as an orphaned-but-undeletable Production field |
 | Time zones | Store UTC, display local | Standard practice |
 | Time-of-day drill-down | Tap a period to expand to hourly bars in place | Sparse data makes 24 bars up front noise; detail on demand only |
 | Drill-down granularity floor | Hourly for first pass; half-hour deferred | Hourly is enough to locate a spike; finer resolution is "later" |
@@ -3335,7 +3325,7 @@ Summary of all design decisions made during the design phase.
 | Quick-log widget store-unavailable | Keeps the tap (write enqueues + syncs later), replaces the count with `Count unavailable` / `ellipsis`, keeps habit tint | UC-W5 requires offline writes to persist; only the count *display* is unavailable, so the card stays loggable and never shows a false `0` |
 | Quick-log widget haptics / motion / announcements | None — platform-limited in a widget extension | Widgets can't fire haptics, animate timeline reloads, or post `UIAccessibility` announcements; the count change on reload is the only feedback |
 | Watch app purpose | Single-screen, single-tap resisted log from the wrist (the wrist-native twin of the widget) | The wrist is the lowest-friction surface for the core action; no phone needed in the urge moment |
-| Watch logged habit | Opens on the default habit (`UserSettings.defaultHabitId`), fallback to sole/first habit, always named on screen | The target is never ambiguous. Switching, deferred to Later in v1, now ships as a vertical pager |
+| Watch logged habit | Opens on the first non-archived habit in `Habit.displayOrder`, always named on screen | The target is never ambiguous, and it is the *same* habit the phone's Log screen opens on without a second setting to sync. Switching, deferred to Later in v1, now ships as a vertical pager |
 | Watch action | One tap writes one `resisted` event (intensity nil, no tags) via shared `TemptationLogger.logResisted` | Mirrors the in-app and widget single-tap default (UC-O1 / UC-W1); identical event shape, no schema change |
 | Watch confirmation | Taptic Engine success haptic + neutral on-screen "Logged"; no notification, no banner/undo | The watch is a separate haptic stack (unaffected by phone haptics bug #48); correction/undo live on the phone |
 | Watch data parity | CloudKit sync of the same container (`iCloud.com.resistor.app`), **not** App Group | App Groups do not bridge iPhone↔Watch (separate devices); cross-device parity must come from CloudKit. Primary feasibility dependency for v1 |


### PR DESCRIPTION
Closes #60.

The app had two orderings the user could set and no rule about which won: a drag
order on the Habits screen, and a `defaultHabitId` flag set from a row's context
menu. The list could show one habit first and the Log screen open on another,
with a "Default" badge as the only clue.

## What changed

- **Badge and context menu gone.** No more "Default" chip, no "Set as Default" /
  "Remove as Default"; `setDefaultHabit` deleted.
- **First habit in `Habit.displayOrder` is the default.** `LogViewModel.init`
  loses its `defaultHabitId` parameter — it already fetched in display order, so
  index 0 was always the answer. Onboarding stops writing the field.
  `WatchLogStore.resolveTargetHabit` is now pick → `active.first`.
- **`WatchLogState.habitUnavailable` deleted.** It existed to cover a *stored*
  target gone stale. With nothing stored, archiving the target just promotes the
  next habit, so the state was unreachable — its view branch went too.
- **Grip glyph** (`line.3.horizontal`, `.tertiary`) on each active row when there
  are 2+ habits. Out of edit mode a `List` gives no hint the order is the user's,
  and the order now decides what the app opens on. It stands down in edit mode
  rather than doubling the system's own grip, and it's tappable, because a drag
  on it does nothing until the list is editing.

`UserSettings.defaultHabitId` itself stays — a Production CloudKit field can
never be removed. It's orphaned alongside `showContextPrompt` and still merged by
`mergeDuplicates` so the value survives if the setting ever comes back.

## The risky part

`HabitsView` now owns its `isEditing` state and installs `\.editMode` itself
instead of using `EditButton`. `EditButton` writes to the `editMode` the
`NavigationStack` installs *below* `HabitsView`'s own environment, so the rows
could never have read it to know when to stand down.

`testHabitOrderDecidesWhichHabitLogOpensOn` pins both halves: that "Edit" really
reaches UIKit (the grips exist), and that a drag moves which habit Log opens on.
It failed first on a wrong query — the grip's label is `Reorder Sugar`, not
identifier `Reorder` — and passes now.

## Verification

iOS build, watch build, 312 unit tests + 2 UI assertion tests, all passing.
Habits screen screenshotted light and dark. Release notes written.

Net −25 lines of code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sdMoCETcfDumJBdarLpba