### PR TITLE
Use hand-written TestFlight notes on merge commits

### DIFF
--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -26,3 +26,14 @@ Worth checking:
   rather than showing an error.
 - VoiceOver: the grip is deliberately skipped; reordering is reachable through
   the "Edit" button.
+
+Also in this build, and never described to you: the previous build's two Log
+screen layout fixes. Its release notes came out as "Merge pull request #66 …"
+because of a bug in how these notes were assembled, now fixed. So if you skipped
+them:
+
+- The habit pager (arrows and dots) moved from above the habit card to below it,
+  under the "Tap or hold to log" line.
+- A habit with no description had its icon and name sitting high with empty space
+  underneath; they're now centred in the card. Swiping between a habit with a
+  description and one without should not resize the card or make it jump.

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -43,10 +43,19 @@ echo "Set CURRENT_PROJECT_VERSION to $CI_BUILD_NUMBER"
 #
 # Subject only, never the body: these commit messages explain implementation rationale to
 # whoever reads git history later, which is the wrong register entirely for a tester.
+#
+# `-m --first-parent` is load-bearing, and its absence silently defeated the whole
+# mechanism. Everything lands on main through `gh pr merge --merge`, so the commit being
+# built is a MERGE commit — and plain `git diff-tree -r` prints *nothing at all* for a
+# merge, rather than the merge's changes. So the grep never matched, every build fell
+# through to the fallback, and hand-written notes were overwritten with "Merge pull
+# request #NN from …". `--first-parent` diffs the merge against main-as-it-was, which is
+# exactly "what this push added"; `-m` is what makes diff-tree emit a merge diff in the
+# first place. Verified on a real merge commit before and after: 0 paths, then 16.
 NOTES=TestFlight/WhatToTest.en-US.txt
 mkdir -p TestFlight
 
-if git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null | grep -qx "$NOTES"; then
+if git diff-tree --no-commit-id --name-only -r -m --first-parent HEAD 2>/dev/null | grep -qx "$NOTES"; then
   echo "Using hand-written test notes from this commit"
 else
   git log -1 --pretty=format:'%s' > "$NOTES"


### PR DESCRIPTION
Every hand-written release note written so far was silently discarded.

## The bug

`ci_scripts/ci_post_clone.sh` only honours `TestFlight/WhatToTest.en-US.txt` if
the commit being built touched it:

```sh
git diff-tree --no-commit-id --name-only -r HEAD
```

Everything lands on `main` through `gh pr merge --merge`, so the commit Xcode
Cloud builds is a **merge commit** — and plain `git diff-tree -r` prints *nothing
at all* for a merge rather than the merge's changes. The grep never matched, every
build fell through to the fallback, and the notes on disk were overwritten with
the commit subject: `Merge pull request #NN from …`.

That's what testers got for #66 (the Log screen layout fixes) and what #67 is
getting right now.

## The fix

`-m` is what makes `diff-tree` emit a merge diff at all; `--first-parent` diffs
the merge against `main`-as-it-was, which is exactly "what this push added".

Verified on three shapes against the real history:

| commit | touches notes? | matches? |
|---|---|---|
| `a8cbfff` (merge of #67) | yes | ✅ was 0 paths, now 16 |
| plain commit on this branch | yes | ✅ |
| `c5170d6` (CI fix only) | no | ✅ correctly does **not** match |

That third row matters: the "touched by this commit" test exists so notes can't go
stale and describe the previous build, and the script's own comment argues stale
notes are "worse than blank, because stale notes read as true". The guard still
works — it was just also eating every good note.

## Notes content

Rewritten to cover the habit-ordering change, plus a short section on the previous
build's Log screen layout fixes, since testers only ever saw
`Merge pull request #66 …` for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sdMoCETcfDumJBdarLpba