### PR TITLE
Insights habit order, and Log card sizing

### DIFF
--- a/Resistor/Models/Habit.swift
+++ b/Resistor/Models/Habit.swift
@@ -52,6 +52,19 @@ extension Habit {
         SortDescriptor(\Habit.id, order: .forward)
     ]
 
+    /// How many lines the Log card gives a description before truncating, and
+    /// the input cap that keeps a description inside them.
+    ///
+    /// The Log card is the only place a description is read (the editor is
+    /// somewhere the user goes deliberately), and that column doesn't scroll —
+    /// so the card can't just grow to fit any amount of text, and truncating
+    /// there makes the tail of a long description unreadable anywhere. Capping
+    /// input at roughly what fits is the honest trade: 120 characters is about
+    /// four lines at default Dynamic Type, so a description written under the
+    /// cap is shown whole. The two constants move together.
+    static let descriptionLineLimit = 4
+    static let descriptionCharacterLimit = 120
+
     /// The `sortOrder` a newly created habit should take so it lands at the end
     /// of the list rather than jumping to the top of a reordered one.
     static func nextSortOrder(in context: ModelContext) -> Int {

--- a/Resistor/ViewModels/InsightsViewModel.swift
+++ b/Resistor/ViewModels/InsightsViewModel.swift
@@ -46,7 +46,7 @@ final class InsightsViewModel {
     func fetchHabits() {
         let descriptor = FetchDescriptor<Habit>(
             predicate: #Predicate { !$0.isArchived },
-            sortBy: [SortDescriptor(\.createdAt)]
+            sortBy: Habit.displayOrder
         )
         do {
             habits = try modelContext.fetch(descriptor)

--- a/Resistor/Views/HabitsView.swift
+++ b/Resistor/Views/HabitsView.swift
@@ -434,9 +434,11 @@ struct HabitsView: View {
                         set: { vm.habitName = $0 }
                     ))
 
+                    // Capped so it can't outrun the Log card, which is the only
+                    // place a description is read and can't scroll.
                     TextField("Description (optional)", text: Binding(
                         get: { vm.habitDescription },
-                        set: { vm.habitDescription = $0 }
+                        set: { vm.habitDescription = String($0.prefix(Habit.descriptionCharacterLimit)) }
                     ), axis: .vertical)
                     .lineLimit(2...4)
                 }

--- a/Resistor/Views/LogView.swift
+++ b/Resistor/Views/LogView.swift
@@ -408,26 +408,64 @@ struct LogView: View {
         }
     }
 
+    /// Icon, name and (if there is one) description, laid out identically for
+    /// the visible card and for the hidden copies that size it. `glowing` is
+    /// false for those copies so their subtree doesn't depend on `holdProgress`
+    /// and SwiftUI can leave them alone for the length of a hold.
+    @ViewBuilder
+    private func cardContent(_ habit: Habit, glowing: Bool) -> some View {
+        let habitColor = Color(hex: habit.colorHex ?? "#007AFF") ?? .blue
+
+        VStack(spacing: 16) {
+            // Icon — gets its own glow during hold. Boxed to a fixed height
+            // because SF Symbols don't share a bounding box at a given point
+            // size: `sun.max.fill`'s rays make it 3pt taller than `circle.fill`,
+            // enough on its own to give two habits differently-sized cards. The
+            // box is a constant rather than a scaled value because
+            // `.system(size:)` is itself fixed and ignores Dynamic Type. Nothing
+            // clips — a taller symbol just overflows into the stack spacing.
+            Image(systemName: habit.iconName ?? "circle.fill")
+                .font(.system(size: 48))
+                .frame(height: 56)
+                .foregroundStyle(habitColor)
+                .shadow(
+                    color: habitColor.opacity(glowing && isHolding ? holdProgress * 0.8 : 0),
+                    radius: glowing && isHolding ? 6 + holdProgress * 14 : 0
+                )
+
+            // Name — one line always. A long name scales down rather than
+            // wrapping, so it can't add height (see the description note).
+            Text(habit.name)
+                .font(.title)
+                .fontWeight(.bold)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+
+            // Description — omitted entirely when there isn't one, so an
+            // undescribed habit contributes no height here at all. The line cap
+            // is a backstop for descriptions written before the input cap
+            // existed, or wrapped further by a large Dynamic Type size.
+            //
+            // `fixedSize` because a Text is compressible: the enclosing column
+            // will hand it less height than it asked for and let it truncate
+            // rather than shrink its own spacers, so without this a two-line
+            // description rendered as one truncated line. The old fixed
+            // `lineLimit(2, reservesSpace: true)` happened to resist that by
+            // pinning a minimum; a plain line cap doesn't.
+            if let description = habit.habitDescription, !description.isEmpty {
+                Text(description)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(Habit.descriptionLineLimit)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal)
+            }
+        }
+    }
+
     private func habitCard(_ habit: Habit, vm: LogViewModel) -> some View {
         let habitColor = Color(hex: habit.colorHex ?? "#007AFF") ?? .blue
-        // An empty string measures short even under `lineLimit(_:reservesSpace:)`
-        // — it reserved ~10pt where two lines want ~41. A single space carries
-        // real line metrics and renders as nothing, so a habit with no
-        // description gets a card the exact size of one that has a description.
-        let rawDescription = habit.habitDescription ?? ""
-        let description = rawDescription.isEmpty ? " " : rawDescription
-        // …and that reserve is all below the name, so an undescribed card drew
-        // its icon+name at the top over a dead band. Slide them down half of it.
-        // An `offset` because it moves pixels without touching layout: the card
-        // still measures identically to a described one, which is what
-        // `testHabitCardSizeIsIndependentOfDescription` pins. Rebalancing the
-        // padding or splitting the reserve into a blank line above and below
-        // both change the height (two one-line reserves run 1.7pt over one
-        // two-line reserve) — a point of slop in a nudge is invisible, a point
-        // in the height resizes a page mid-slide.
-        let blankDescriptionShift: CGFloat = rawDescription.isEmpty
-            ? (UIFont.preferredFont(forTextStyle: .body).lineHeight * 2 + 16) / 2
-            : 0
         let cardScale = reduceMotion ? 1.0 : 1.0 + (holdProgress * 0.08)
         let glowPulseIntensity: CGFloat = glowPulsing ? 1.0 : 0.5
         // Resting affordance: a steady habit-color border so the card reads as
@@ -444,47 +482,26 @@ struct LogView: View {
         // bindings type-checks each sub-expression independently; the resulting
         // view tree is identical.
 
-        // Inner content — icon, name, optional description.
-        let content = VStack(spacing: 16) {
-            // Icon — gets its own glow during hold. Boxed to a fixed height
-            // because SF Symbols don't share a bounding box at a given point
-            // size: `sun.max.fill`'s rays make it 3pt taller than `circle.fill`,
-            // enough on its own to give two habits differently-sized cards. The
-            // box is a constant rather than a scaled value because
-            // `.system(size:)` is itself fixed and ignores Dynamic Type. Nothing
-            // clips — a taller symbol just overflows into the stack spacing.
-            Image(systemName: habit.iconName ?? "circle.fill")
-                .font(.system(size: 48))
-                .frame(height: 56)
-                .foregroundStyle(habitColor)
-                .shadow(
-                    color: habitColor.opacity(isHolding ? holdProgress * 0.8 : 0),
-                    radius: isHolding ? 6 + holdProgress * 14 : 0
-                )
+        // Inner content — icon, name, optional description. Every card still has
+        // to be the same size (it's a swipeable page; a per-habit height would
+        // resize the page mid-slide and shove the column below it around), so
+        // the stack lays out *every* habit's content at once, hidden, and draws
+        // the real one centered over it. Height is therefore the tallest card
+        // the user actually has, not a fixed two-line reserve: with no
+        // descriptions there's no dead band under the name and the icon sits
+        // centered, and a described habit gets the room its own text needs.
+        // Centered rather than nudged down by half the slack — a ZStack does it
+        // for free and can't drift out of step with the reserve the way a
+        // hand-computed offset did.
+        let content = ZStack {
+            ForEach(vm.habits, id: \.id) { other in
+                cardContent(other, glowing: false)
+                    .hidden()
+                    .accessibilityHidden(true)
+            }
 
-            // Name — one line always. A long name scales down rather than
-            // wrapping, so it can't add height (see the description note).
-            Text(habit.name)
-                .font(.title)
-                .fontWeight(.bold)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-
-            // Description — always rendered and always two lines tall, even when
-            // absent or one line, because every habit card must be the same size:
-            // the card is a swipeable page, and a per-habit height would resize
-            // the page mid-slide and shove the rest of the column around. Height
-            // comes from the reserved line count, so it still tracks Dynamic Type
-            // instead of being pinned to a magic number. Cost: a description over
-            // two lines truncates.
-            Text(description)
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .lineLimit(2, reservesSpace: true)
-                .padding(.horizontal)
+            cardContent(habit, glowing: true)
         }
-        .offset(y: blankDescriptionShift)
         .padding(32)
         .frame(maxWidth: .infinity)
 
@@ -763,8 +780,13 @@ private struct AddHabitFromLogSheet: View {
             Form {
                 Section {
                     TextField("Habit name", text: $name)
-                    TextField("Description (optional)", text: $description, axis: .vertical)
-                        .lineLimit(2...4)
+                    // Capped so it can't outrun the Log card, which is the only
+                    // place a description is read and can't scroll.
+                    TextField("Description (optional)", text: Binding(
+                        get: { description },
+                        set: { description = String($0.prefix(Habit.descriptionCharacterLimit)) }
+                    ), axis: .vertical)
+                    .lineLimit(2...4)
                 }
 
                 Section("Color") {

--- a/Resistor/Views/OnboardingView.swift
+++ b/Resistor/Views/OnboardingView.swift
@@ -140,9 +140,11 @@ struct OnboardingView: View {
                     .textFieldStyle(.roundedBorder)
                     .padding(.horizontal)
 
+                    // Capped so it can't outrun the Log card, which is the only
+                    // place a description is read and can't scroll.
                     TextField("Description (optional)", text: Binding(
                         get: { vm.habitDescription },
-                        set: { vm.habitDescription = $0 }
+                        set: { vm.habitDescription = String($0.prefix(Habit.descriptionCharacterLimit)) }
                     ))
                     .textFieldStyle(.roundedBorder)
                     .padding(.horizontal)

--- a/ResistorTests/InsightsViewModelTests.swift
+++ b/ResistorTests/InsightsViewModelTests.swift
@@ -33,6 +33,22 @@ final class InsightsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.habits.first?.name, "Active")
     }
 
+    /// Insights lists habits in `Habit.displayOrder` like every other list, so a
+    /// drag on the Habits screen reorders this picker too.
+    func testHabitsFollowDisplayOrder() throws {
+        let first = TestHelpers.makeHabit(name: "First", createdAt: Date(timeIntervalSince1970: 0))
+        let second = TestHelpers.makeHabit(name: "Second", createdAt: Date(timeIntervalSince1970: 100))
+        first.sortOrder = 1
+        second.sortOrder = 0
+        context.insert(first)
+        context.insert(second)
+        try context.save()
+
+        let vm = InsightsViewModel(modelContext: context)
+
+        XCTAssertEqual(vm.habits.map(\.name), ["Second", "First"])
+    }
+
     func testSelectedHabitNilWhenNoHabits() throws {
         let vm = InsightsViewModel(modelContext: context)
         XCTAssertNil(vm.selectedHabit)

--- a/ResistorUITests/SnapshotTests.swift
+++ b/ResistorUITests/SnapshotTests.swift
@@ -312,39 +312,81 @@ final class SnapshotTests: XCTestCase {
         if cancel.exists { cancel.tap() }
     }
 
-    /// Captures a full-screen screenshot and attaches it under `name`.
     /// The Log card is a swipeable page, so its size must not depend on which
     /// habit it shows — a card that resizes mid-slide shoves the rest of the
-    /// column around. A habit with no description used to render a shorter card
-    /// (the description Text was omitted entirely); it now reserves its lines.
-    /// Creates a description-less habit and asserts its card matches a described
-    /// one. Lives here rather than in its own file because the UITest target has
-    /// an explicit file list, not a synchronized folder group.
-    func testHabitCardSizeIsIndependentOfDescription() {
+    /// column around. Every card therefore takes its height from the tallest
+    /// description any habit has, laid out hidden behind the visible one.
+    ///
+    /// Two halves, and the second is what stops the old fixed two-line reserve
+    /// coming back: a description-less habit's card must match a described one
+    /// (uniformity), *and* adding a habit whose description runs longer than any
+    /// existing one must grow every card (the height follows the real text, so
+    /// an app with no descriptions has no dead band and a long one isn't cut
+    /// off). Lives here rather than in its own file because the UITest target
+    /// has an explicit file list, not a synchronized folder group.
+    func testHabitCardSizeFollowsTheLongestDescription() {
         let app = XCUIApplication()
         app.launchArguments += ["-uiTestMode"]
         app.launch()
 
         let described = app.buttons["Log temptation for Sugar"]
         XCTAssertTrue(described.waitForExistence(timeout: 5), "seeded habit card not found")
-        let describedSize = described.frame.size
+        let seededSize = described.frame.size
 
+        addHabit(app, name: "Bare", description: nil)
+        let bare = app.buttons["Log temptation for Bare"]
+        showCard(app, bare, "new habit card not reachable")
+
+        XCTAssertEqual(bare.frame.width, seededSize.width, accuracy: 0.5)
+        XCTAssertEqual(bare.frame.height, seededSize.height, accuracy: 0.5,
+                       "a habit with no description must not get a shorter card")
+
+        // Longer than either seeded description, so it has to lengthen the card.
+        addHabit(app, name: "Wordy", description: String(repeating: "long enough ", count: 10))
+        let wordy = app.buttons["Log temptation for Wordy"]
+        showCard(app, wordy, "long-description card not reachable")
+        // Read now — paging away leaves `wordy` out of the tree entirely, and
+        // `frame` on a missing element fails rather than returning a stale value.
+        let wordyHeight = wordy.frame.height
+
+        XCTAssertGreaterThan(wordyHeight, seededSize.height,
+                             "the card must grow to fit a description longer than the reserve")
+        showCard(app, bare, "bare card not reachable after adding a longer description")
+        XCTAssertEqual(bare.frame.height, wordyHeight, accuracy: 0.5,
+                       "every card must match the tallest one")
+    }
+
+    /// Creates a habit from the Log screen's add sheet.
+    private func addHabit(_ app: XCUIApplication, name: String, description: String?) {
         app.buttons["addHabitButtonLog"].tap()
         let nameField = app.textFields["Habit name"]
         XCTAssertTrue(nameField.waitForExistence(timeout: 5), "add-habit sheet did not appear")
         nameField.tap()
-        nameField.typeText("Bare")
-        app.buttons["Save"].tap()
+        nameField.typeText(name)
 
-        // New habits take the next sortOrder, so the new one is last in the carousel.
-        let bare = app.buttons["Log temptation for Bare"]
-        for _ in 0..<3 where !bare.exists {
+        if let description {
+            // `axis: .vertical` can surface as either, depending on the runtime.
+            let field = app.textFields["Description (optional)"]
+            let descriptionField = field.exists ? field : app.textViews["Description (optional)"]
+            XCTAssertTrue(descriptionField.waitForExistence(timeout: 2), "description field not found")
+            descriptionField.tap()
+            descriptionField.typeText(description)
+        }
+
+        app.buttons["Save"].tap()
+    }
+
+    /// Pages the carousel until `card` is the one on screen. New habits take the
+    /// next sortOrder, so they land at the end. Waits rather than testing
+    /// `.exists` before each tap: right after a sheet dismisses, the card behind
+    /// it isn't in the tree yet, and an instantaneous check sends the pager off
+    /// on a lap it didn't need.
+    private func showCard(_ app: XCUIApplication, _ card: XCUIElement, _ message: String) {
+        for _ in 0..<8 {
+            if card.waitForExistence(timeout: 1) { return }
             app.buttons["Next habit"].tap()
         }
-        XCTAssertTrue(bare.waitForExistence(timeout: 2), "new habit card not reachable")
-
-        XCTAssertEqual(bare.frame.width, describedSize.width, accuracy: 0.5)
-        XCTAssertEqual(bare.frame.height, describedSize.height, accuracy: 0.5)
+        XCTFail(message)
     }
 
     /// "Edit" really puts the habits list into edit mode. `HabitsView` owns its

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,39 +1,13 @@
-The default habit is now just the top of your habits list.
+The Insights habit picker now follows the order you set on the Habits screen.
 
-The "Default" badge is gone, and so is "Set as Default" in the row's context
-menu. Instead, whichever habit sits first on the Habits screen is the one the
-Log screen and the Apple Watch open on. You change it by dragging.
-
-Each habit row now shows a small grip icon on the right when you have two or
-more habits, so it's visible that the order is yours to set. Tapping it turns on
-edit mode; the toolbar "Edit" button still does the same thing.
-
-Whatever you had set as your default before is not carried over — the habit that
-opens is now purely a matter of list order, so check the order is what you want.
+Every other habit list in the app — Log, Habits, the widget's picker, the watch
+— already sorted by the order you drag. Insights didn't; it was still listing
+habits oldest-first, so reordering had no effect there and it opened on whichever
+habit you created first.
 
 Worth checking:
 
-- With two or more habits, drag one to the top on the Habits screen, then go to
-  the Log tab. It should open on the habit you just moved to the top.
-- Same check on the Apple Watch: after the phone syncs, the watch should open on
-  the same habit the phone does. This is the part most at risk.
-- With exactly one habit, the grip icon and the "Edit" button should both be
-  absent — there's nothing to reorder.
-- The grip icon should disappear while you're in edit mode (the system draws its
-  own there). You shouldn't ever see two grips on one row.
-- Tapping a habit row still opens its editor, in and out of edit mode.
-- Archive the top habit. Log and the watch should move to the next one down
-  rather than showing an error.
-- VoiceOver: the grip is deliberately skipped; reordering is reachable through
-  the "Edit" button.
-
-Also in this build, and never described to you: the previous build's two Log
-screen layout fixes. Its release notes came out as "Merge pull request #66 …"
-because of a bug in how these notes were assembled, now fixed. So if you skipped
-them:
-
-- The habit pager (arrows and dots) moved from above the habit card to below it,
-  under the "Tap or hold to log" line.
-- A habit with no description had its icon and name sitting high with empty space
-  underneath; they're now centred in the card. Swiping between a habit with a
-  description and one without should not resize the card or make it jump.
+- With two or more habits, drag one to the top on the Habits screen, then open
+  Insights. The picker should list them in that order, and Insights should open
+  on the habit you moved to the top.
+- Archive a habit. It should drop out of the Insights picker, as before.

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,13 +1,25 @@
-The Insights habit picker now follows the order you set on the Habits screen.
+Two fixes: the Insights habit picker now follows the order you set, and habit
+descriptions on the Log screen are no longer cut off.
 
-Every other habit list in the app — Log, Habits, the widget's picker, the watch
-— already sorted by the order you drag. Insights didn't; it was still listing
-habits oldest-first, so reordering had no effect there and it opened on whichever
-habit you created first.
+The Insights picker was the last habit list still sorting oldest-first, so
+reordering on the Habits screen had no effect there and Insights opened on
+whichever habit you created first.
+
+On the Log screen, every habit card reserved two lines for a description whether
+or not the habit had one — so a habit without a description showed its icon and
+name pushed up above an empty band, and a description longer than two lines was
+truncated with no other place to read it. Cards are now the height of the longest
+description you've actually written, and descriptions are capped at 120
+characters when you type them rather than cut off where they're shown.
 
 Worth checking:
 
 - With two or more habits, drag one to the top on the Habits screen, then open
-  Insights. The picker should list them in that order, and Insights should open
-  on the habit you moved to the top.
-- Archive a habit. It should drop out of the Insights picker, as before.
+  Insights. The picker should list them in that order and open on the habit you
+  moved to the top.
+- Add a habit with no description. Its card should be compact, with the icon and
+  name centered — no empty space underneath.
+- Give one habit a long description. Every card should grow to the same height,
+  and swiping between them shouldn't make the screen jump.
+- In the habit editor, try typing past 120 characters of description. It should
+  stop accepting input rather than silently truncating later.

--- a/docs/design.md
+++ b/docs/design.md
@@ -2357,7 +2357,7 @@ All interactive elements meet 44x44pt minimum tap target.
 
 ### Component Catalog
 
-**Habit Card:** Icon (48pt, habit color) + name + optional description. Background: habit color @ 15% opacity. Corner radius 20pt.
+**Habit Card:** Icon (48pt, habit color) + name + optional description. Background: habit color @ 15% opacity. Corner radius 20pt. The card is a swipeable page, so every card is the height of the tallest description the user has written — with no descriptions at all there is no space reserved for one and the icon and name sit centered. The card is the only place a description is read, and it can't scroll, so descriptions are capped at 120 characters on input (about four lines at default Dynamic Type) rather than truncated where they're shown.
 
 **Primary Button (Log Temptation):** White text on accent color. Full width, 16pt corner radius, 20pt vertical padding.
 


### PR DESCRIPTION
Two independent fixes, both reported from use.

### Insights ignored the habit order

`InsightsViewModel.fetchHabits()` was the one habit fetch in the app still sorted by `createdAt`. A drag on the Habits screen reordered Log, Habits, the widget and the watch, but the Insights picker kept listing habits oldest-first — and opened on whichever habit was created first. Now sorts by `Habit.displayOrder` like everything else. Pinned by `testHabitsFollowDisplayOrder`.

### The Log card reserved space for a description whether there was one or not

Every card reserved two lines, so:

- an undescribed habit drew its icon and name above a dead band (a hand-computed `offset` slid them down half of it, which only half worked), and
- a description longer than two lines truncated — on the only screen where a description is ever read.

Cards still have to match each other, since the card is a swipeable page. They now match at the height of the tallest description any habit *actually has*: the `ZStack` lays out every habit's content hidden and draws the real one centered over it. With no descriptions there's no reserve at all, and the icon and name centre themselves.

Truncation is prevented at the input instead — `Habit.descriptionCharacterLimit`, 120 characters, roughly four lines at default Dynamic Type, clamped in all three description fields. `lineLimit(4)` stays as a backstop for descriptions written before the cap and for accessibility text sizes.

One thing worth flagging for review: `fixedSize` on the description is load-bearing. Without it the enclosing column hands the `Text` less height than it asked for and lets it truncate rather than shrink its own spacers — the seeded two-line description was rendering as one clipped line ("Reaching for sweets when stres…") on `main`. The old `lineLimit(2, reservesSpace:)` had been resisting that by accident.

### Tests

`testHabitCardSizeIsIndependentOfDescription` → `testHabitCardSizeFollowsTheLongestDescription`. It keeps the uniformity assertion and adds the other half: a habit whose description is longer than any existing one must grow *every* card. That second half is what stops the fixed reserve coming back.

313 unit + 2 UI tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sdMoCETcfDumJBdarLpba