### PR TITLE
Deepen the shallow clone so the TestFlight notes check works

### DIFF
--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,25 +1,10 @@
-Two fixes: the Insights habit picker now follows the order you set, and habit
-descriptions on the Log screen are no longer cut off.
+No app changes in this build. It is identical to build 34.
 
-The Insights picker was the last habit list still sorting oldest-first, so
-reordering on the Habits screen had no effect there and Insights opened on
-whichever habit you created first.
+This build exists to fix how these release notes get delivered. Build 34 shipped
+with "Merge pull request #70 …" here instead of the notes written for it — if you
+saw that, the correct notes have since been restored on build 34, and that is
+where the things worth testing are listed (the Insights habit order, and habit
+descriptions on the Log screen).
 
-On the Log screen, every habit card reserved two lines for a description whether
-or not the habit had one — so a habit without a description showed its icon and
-name pushed up above an empty band, and a description longer than two lines was
-truncated with no other place to read it. Cards are now the height of the longest
-description you've actually written, and descriptions are capped at 120
-characters when you type them rather than cut off where they're shown.
-
-Worth checking:
-
-- With two or more habits, drag one to the top on the Habits screen, then open
-  Insights. The picker should list them in that order and open on the habit you
-  moved to the top.
-- Add a habit with no description. Its card should be compact, with the icon and
-  name centered — no empty space underneath.
-- Give one habit a long description. Every card should grow to the same height,
-  and swiping between them shouldn't make the screen jump.
-- In the habit editor, try typing past 120 characters of description. It should
-  stop accepting input rather than silently truncating later.
+Nothing to test here beyond confirming the app still launches. If you are reading
+this sentence rather than a commit subject, the fix worked.

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -52,6 +52,28 @@ echo "Set CURRENT_PROJECT_VERSION to $CI_BUILD_NUMBER"
 # request #NN from …". `--first-parent` diffs the merge against main-as-it-was, which is
 # exactly "what this push added"; `-m` is what makes diff-tree emit a merge diff in the
 # first place. Verified on a real merge commit before and after: 0 paths, then 16.
+#
+# And `-m --first-parent` was still not enough, because it fixes the wrong half of
+# the problem. Xcode Cloud clones with:
+#
+#   git fetch --depth 1 origin <sha> && git checkout <sha>
+#
+# — a shallow clone containing the merge commit and NOTHING ELSE. diff-tree needs
+# the first parent to diff against, and that object isn't in the repository, so it
+# emits zero paths for the same reason a plain `-r` does. Build 34 shipped with
+# "Merge pull request #70 from …" as its release notes despite the file being in
+# the commit; the log line was "Generated test notes from the commit subject".
+#
+# Both previous versions of this were verified on a full local clone, where the
+# parent is always present, so both looked correct and neither was. `--deepen 1`
+# pulls the merge's parents in, which is the whole requirement. Verified by
+# reproducing the shallow clone (git init; fetch --depth 1 <merge sha>; checkout):
+# 0 paths before, 9 after, notes file among them.
+#
+# `|| true` because `set -eu` is in force and a failed deepen must degrade to the
+# commit-subject fallback, never abort the build over release-note prose.
+git fetch --deepen 1 origin 2>/dev/null || true
+
 NOTES=TestFlight/WhatToTest.en-US.txt
 mkdir -p TestFlight
 


### PR DESCRIPTION
Build 34 shipped with `Merge pull request #70 from silentArtifact/…` as its TestFlight release notes, even though `TestFlight/WhatToTest.en-US.txt` was in the commit. The post-clone log confirms the fallback fired:

```
Set CURRENT_PROJECT_VERSION to 34
Generated test notes from the commit subject
--- WhatToTest.en-US.txt ---
Merge pull request #70 from silentArtifact/fix/insights-order-and-log-card
```

### Cause

Not the merge-diff semantics this time. From the Fetch source code log:

```
git fetch --depth 1 origin 9fd7f8f6d2bbf5fdfbca0daa59b0c90f2c0ecc82
git checkout 9fd7f8f6d2bbf5fdfbca0daa59b0c90f2c0ecc82
```

Xcode Cloud shallow-clones **only the merge commit**. `diff-tree --first-parent` needs the first parent to diff against, and that object isn't in the repository — so it emits zero paths, exactly like the plain `-r` did before #68.

`git fetch --deepen 1 origin` pulls the parents in. `|| true` because `set -eu` is in force and a failed deepen must degrade to the fallback, never fail a build over release-note prose.

### Why this one is verified and the last two weren't

Both previous versions were checked on a full local clone, where the parent is always present, so both looked correct. This was tested against a reproduced shallow clone (`git init` → `fetch --depth 1 <merge sha>` → `checkout`):

- before the deepen: **0 paths**
- after: **9 paths**, including `TestFlight/WhatToTest.en-US.txt`
- the edited script run end to end under that clone prints `Using hand-written test notes from this commit`

### Notes handling

Build 34's "What to Test" has been corrected directly in App Store Connect, so testers on it see the real notes. This build's notes state the app is unchanged from 34 — which also makes build 35 a live check: if the notes render instead of a commit subject, the fix holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sdMoCETcfDumJBdarLpba