### PR TITLE
Open the map from Top Locations, and let an event's habit and tags be corrected

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,6 +340,28 @@ underneath), not a `Chart` with a category axis: place names are long enough
 ("Financial District, San Francisco") that Charts drew the labels inside the plot
 on top of their own bars.
 
+**The card is the way to the Event Map**, and it renders unconditionally — the
+"View Map" link that used to sit below it is gone, since it opened an unfocused
+map and asked the user to find again the place they had just tapped past. Two
+targets, no nesting:
+
+- **A row** pushes the map framed on that place
+  (`EventMapView(habit:focusLocation:)`, camera fitted to that grouping name's
+  pins, floor ~500 m so a lone pin isn't zoomed to the pavement).
+- **The header's "Map ›" accessory** pushes it unfocused, and is what makes the
+  card safe to render empty.
+
+**Neither the card nor the accessory may be gated on `locationDistribution()`.**
+An event carries a coordinate long before it carries a name — the geocode can
+fail or return nothing — and naming is done *on the map*, so gating strands
+exactly the user who has never named anything: no rows → no card → no map → no
+way to ever get a row. The empty body distinguishes the two cases via
+`InsightsViewModel.hasAnyLocatedEvent`, which is computed over the habit's
+**whole history**, not `cachedEventsInRange`: the map isn't range-scoped, so a
+7-day range must not claim "No location data yet" over a map full of pins.
+`testUnnamedCoordinatesStillCountAsLocationData` and
+`testLocatedEventOutsideRangeStillCountsAsLocationData` pin both halves.
+
 ### Pattern Detection (Insights "Patterns" card)
 
 `Services/PatternFinder.swift` answers the question the rest of Insights can't:

--- a/Resistor/Models/TemptationEvent.swift
+++ b/Resistor/Models/TemptationEvent.swift
@@ -139,6 +139,17 @@ extension TemptationEvent {
         return tagRaw
     }
 
+    /// Adds the tag if absent, removes it if present. Removes only the first
+    /// match: a duplicate is a bug from elsewhere, and silently collapsing it
+    /// here would hide it while making one tap take two.
+    func toggleContextTag(_ tagRaw: String) {
+        if let index = contextTags.firstIndex(of: tagRaw) {
+            contextTags.remove(at: index)
+        } else {
+            contextTags.append(tagRaw)
+        }
+    }
+
     var hasLocation: Bool {
         latitude != nil && longitude != nil
     }

--- a/Resistor/ViewModels/InsightsViewModel.swift
+++ b/Resistor/ViewModels/InsightsViewModel.swift
@@ -365,6 +365,19 @@ final class InsightsViewModel {
         locationDistribution().first?.location
     }
 
+    /// Whether the map has any pin to draw. Deliberately over the habit's
+    /// **whole history**, not `cachedEventsInRange`, because the map isn't
+    /// range-scoped — a 7-day range must not report "no location data" while
+    /// the map it links to is full of pins.
+    ///
+    /// Distinct from `locationDistribution().isEmpty`: an event carries a
+    /// coordinate long before it carries a name, and those are exactly the
+    /// events a user goes to the map to name.
+    var hasAnyLocatedEvent: Bool {
+        guard let habit = selectedHabit else { return false }
+        return habit.safeEvents.contains { $0.hasLocation }
+    }
+
     // MARK: - Trigger Patterns
 
     /// Combinations (time × day × place × context) the habit's temptations land

--- a/Resistor/Views/EventMapView.swift
+++ b/Resistor/Views/EventMapView.swift
@@ -8,6 +8,11 @@ struct EventMapView: View {
 
     let habit: Habit?
 
+    /// The Insights grouping name that was tapped, if the map was opened from a
+    /// Top Locations row — the map then opens framed on that place rather than
+    /// on every pin.
+    var focusLocation: String? = nil
+
     /// The event whose spot is being named, driving the `PlaceNameSheet`.
     @State private var namingEvent: TemptationEvent?
 
@@ -29,15 +34,42 @@ struct EventMapView: View {
                 mapContent
             }
         }
-        .navigationTitle("Event Map")
+        .navigationTitle(focusLocation ?? "Event Map")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $namingEvent) { event in
             PlaceNameSheet(event: event)
         }
     }
 
+    /// Frames the pins of `focusLocation` when the map was opened from a Top
+    /// Locations row. A place is a spread of fixes, not a point — a drifting
+    /// GPS or two entrances put its events tens of metres apart — so the camera
+    /// fits their bounding box rather than centring on one of them.
+    private var initialPosition: MapCameraPosition {
+        guard let focusLocation else { return .automatic }
+        let coords = eventsWithLocation
+            .filter { places.groupingName(for: $0) == focusLocation }
+            .compactMap { event -> CLLocationCoordinate2D? in
+                guard let lat = event.latitude, let lon = event.longitude else { return nil }
+                return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+            }
+        guard let first = coords.first else { return .automatic }
+        let lats = coords.map(\.latitude), lons = coords.map(\.longitude)
+        let minLat = lats.min() ?? first.latitude, maxLat = lats.max() ?? first.latitude
+        let minLon = lons.min() ?? first.longitude, maxLon = lons.max() ?? first.longitude
+        return .region(MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: (minLat + maxLat) / 2, longitude: (minLon + maxLon) / 2),
+            // Floor of ~500 m so a single pin isn't zoomed to the pavement,
+            // and 40% headroom so edge pins don't sit under the hint bar.
+            span: MKCoordinateSpan(
+                latitudeDelta: max((maxLat - minLat) * 1.4, 0.005),
+                longitudeDelta: max((maxLon - minLon) * 1.4, 0.005)
+            )
+        ))
+    }
+
     private var mapContent: some View {
-        Map {
+        Map(initialPosition: initialPosition) {
             ForEach(eventsWithLocation) { event in
                 if let lat = event.latitude, let lon = event.longitude {
                     Annotation(

--- a/Resistor/Views/HistoryView.swift
+++ b/Resistor/Views/HistoryView.swift
@@ -229,9 +229,42 @@ struct EventDetailSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Place.createdAt) private var places: [Place]
+    @Query(sort: Habit.displayOrder) private var habits: [Habit]
+    @Query(sort: \ContextTag.createdAt) private var definedTags: [ContextTag]
     let event: TemptationEvent
 
     @State private var showPlaceNameSheet = false
+
+    /// Active habits, plus the event's own if it has since been archived — a
+    /// Picker whose selection isn't among its options warns and renders blank.
+    private var habitOptions: [Habit] {
+        let active = habits.filter { !$0.isArchived }
+        if let current = event.habit, !active.contains(where: { $0.id == current.id }) {
+            return active + [current]
+        }
+        return active
+    }
+
+    /// Selection by id rather than by `Habit`, so the "none" case is a plain
+    /// `nil` tag instead of a doubly-optional model reference.
+    private var habitBinding: Binding<UUID?> {
+        Binding(
+            get: { event.habit?.id },
+            set: { newValue in
+                event.habit = habitOptions.first { $0.id == newValue }
+                try? modelContext.save()
+            }
+        )
+    }
+
+    /// Every tag the user could put on this event: the defined ones, plus any
+    /// raw value already on the event that no longer has a `ContextTag` (a
+    /// legacy enum value, or a tag deleted since it was logged) — otherwise the
+    /// sheet would show a tag it gives no way to remove.
+    private var tagOptions: [String] {
+        let defined = definedTags.map(\.name)
+        return defined + event.contextTags.filter { !defined.contains($0) }
+    }
 
     private var outcomeBinding: Binding<TemptationEvent.Outcome> {
         Binding(
@@ -246,16 +279,30 @@ struct EventDetailSheet: View {
     var body: some View {
         NavigationStack {
             List {
-                // Habit section
-                if let habit = event.habit {
+                // Habit section. Editable, because the common mislog is tapping
+                // the wrong card on the Log screen — the event happened, it was
+                // just filed against the wrong habit.
+                if !habitOptions.isEmpty {
                     Section("Habit") {
-                        HStack(spacing: 12) {
-                            Image(systemName: habit.iconName ?? "circle.fill")
-                                .font(.title2)
-                                .foregroundStyle(Color(hex: habit.colorHex ?? "#007AFF") ?? .blue)
-                            Text(habit.name)
-                                .font(.body)
+                        Picker(selection: habitBinding) {
+                            ForEach(habitOptions) { habit in
+                                Label {
+                                    Text(habit.name)
+                                } icon: {
+                                    Image(systemName: habit.iconName ?? "circle.fill")
+                                }
+                                .tag(Optional(habit.id))
+                            }
+                            // Only offered while the event actually has no
+                            // habit, so a filed event can't be un-filed.
+                            if event.habit == nil {
+                                Text("None").tag(UUID?.none)
+                            }
+                        } label: {
+                            Text("Habit")
                         }
+                        .pickerStyle(.menu)
+                        .accessibilityLabel("Habit")
                     }
                 }
 
@@ -324,11 +371,29 @@ struct EventDetailSheet: View {
                     }
                 }
 
-                // Context section
-                if !event.contextTags.isEmpty {
+                // Context section. Every tag is a row that toggles, rather than
+                // a list of what's set plus an editor elsewhere — context is
+                // usually remembered a moment after the log, so adding one has
+                // to cost the same as removing one.
+                if !tagOptions.isEmpty {
                     Section("Context") {
-                        ForEach(event.contextTags, id: \.self) { tagRaw in
-                            Text(TemptationEvent.displayName(for: tagRaw))
+                        ForEach(tagOptions, id: \.self) { tagRaw in
+                            let isSet = event.contextTags.contains(tagRaw)
+                            Button {
+                                toggleTag(tagRaw)
+                            } label: {
+                                HStack {
+                                    Text(TemptationEvent.displayName(for: tagRaw))
+                                        .foregroundStyle(.primary)
+                                    Spacer()
+                                    if isSet {
+                                        Image(systemName: "checkmark")
+                                            .foregroundStyle(.tint)
+                                    }
+                                }
+                                .contentShape(Rectangle())
+                            }
+                            .accessibilityAddTraits(isSet ? [.isButton, .isSelected] : .isButton)
                         }
                     }
                 }
@@ -400,6 +465,10 @@ struct EventDetailSheet: View {
         HistoryView.timeFormatter.string(from: date)
     }
 
+    private func toggleTag(_ tagRaw: String) {
+        event.toggleContextTag(tagRaw)
+        try? modelContext.save()
+    }
 }
 
 #Preview {

--- a/Resistor/Views/InsightsView.swift
+++ b/Resistor/Views/InsightsView.swift
@@ -103,9 +103,6 @@ struct InsightsView: View {
                     // Period summaries
                     periodSummaries(vm)
 
-                    // View Map link
-                    viewMapButton(vm)
-
                     // View History link
                     viewHistoryButton(vm)
                 }
@@ -874,11 +871,21 @@ struct InsightsView: View {
     @ViewBuilder
     private func topLocationsChart(_ vm: InsightsViewModel) -> some View {
         let data = vm.locationDistribution()
+        let barColor = Color(hex: vm.selectedHabit?.colorHex ?? "#007AFF") ?? .blue
 
-        if !data.isEmpty {
-            let barColor = Color(hex: vm.selectedHabit?.colorHex ?? "#007AFF") ?? .blue
-
-            SectionCard(title: "Top Locations") {
+        // The card is unconditional, and the "Map" accessory with it. Gating
+        // either on `data` would strand the user who most needs the map: an
+        // event carries a coordinate long before it carries a name, and naming
+        // is done *on* the map — so "no named places" must never mean "no way
+        // to reach the map to name one".
+        SectionCard(title: "Top Locations", accessory: AnyView(mapLink(vm))) {
+            if data.isEmpty {
+                Text(vm.hasAnyLocatedEvent
+                     ? "Locations logged, none named yet. Name a spot from the map."
+                     : "No location data yet.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
                 // Not a chart with a category axis. Place names are long
                 // ("Financial District, San Francisco") and Charts had to draw
                 // them inside the plot, where they landed on top of their own
@@ -888,56 +895,67 @@ struct InsightsView: View {
                 VStack(alignment: .leading, spacing: 10) {
                     let maxCount = data.map(\.count).max() ?? 1
                     ForEach(data, id: \.location) { item in
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack(spacing: 8) {
-                                Text(item.location)
-                                    .font(.subheadline)
-                                    .lineLimit(1)
-                                Spacer(minLength: 8)
-                                Text("\(item.count)")
-                                    .font(.subheadline)
-                                    .fontWeight(.medium)
-                                    .monospacedDigit()
-                                    .foregroundStyle(.secondary)
-                            }
+                        // The rows are the way to the map. A separate "View Map"
+                        // link below the card asked the user to open an
+                        // unfocused map and find again the place they were
+                        // already looking at.
+                        NavigationLink {
+                            EventMapView(habit: vm.selectedHabit, focusLocation: item.location)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack(spacing: 8) {
+                                    Text(item.location)
+                                        .font(.subheadline)
+                                        .lineLimit(1)
+                                    Spacer(minLength: 8)
+                                    Text("\(item.count)")
+                                        .font(.subheadline)
+                                        .fontWeight(.medium)
+                                        .monospacedDigit()
+                                        .foregroundStyle(.secondary)
+                                    Image(systemName: "chevron.right")
+                                        .font(.caption2)
+                                        .foregroundStyle(.tertiary)
+                                }
 
-                            GeometryReader { geo in
-                                Capsule()
-                                    .fill(barColor)
-                                    .frame(width: max(geo.size.width * CGFloat(item.count) / CGFloat(maxCount), 3))
+                                GeometryReader { geo in
+                                    Capsule()
+                                        .fill(barColor)
+                                        .frame(width: max(geo.size.width * CGFloat(item.count) / CGFloat(maxCount), 3))
+                                }
+                                .frame(height: 6)
                             }
-                            .frame(height: 6)
+                            .contentShape(Rectangle())
+                            // The count is already stated as text on the line
+                            // above. Combined inside the link's label, not on
+                            // the link itself, so the link keeps its own button
+                            // trait and activation.
+                            .accessibilityElement(children: .combine)
                         }
-                        // The count is already stated as text on the line above.
-                        .accessibilityElement(children: .combine)
+                        .buttonStyle(.plain)
+                        .accessibilityHint("Opens the map for this place.")
                     }
                 }
             }
         }
     }
 
-    @ViewBuilder
-    private func viewMapButton(_ vm: InsightsViewModel) -> some View {
+    /// The card's own way onto the map, unfocused. Rows cover the named places;
+    /// this covers everything else — no names yet, or a place that didn't make
+    /// the top five.
+    private func mapLink(_ vm: InsightsViewModel) -> some View {
         NavigationLink {
             EventMapView(habit: vm.selectedHabit)
         } label: {
-            HStack {
-                Image(systemName: "map")
-                    .font(.body)
-                Text("View Map")
-                    .font(.body)
-                Spacer()
+            HStack(spacing: 2) {
+                Text("Map")
+                    .font(.subheadline)
                 Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(.caption2)
             }
-            .padding()
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color(.secondarySystemGroupedBackground))
-            )
         }
-        .buttonStyle(.plain)
+        .accessibilityLabel("Map")
+        .accessibilityHint("Opens the map of all logged locations.")
     }
 }
 

--- a/ResistorTests/InsightsViewModelTests.swift
+++ b/ResistorTests/InsightsViewModelTests.swift
@@ -668,6 +668,67 @@ final class InsightsViewModelTests: XCTestCase {
         XCTAssertTrue(dist.isEmpty)
     }
 
+    /// The map is reached from the Top Locations card, and naming a place is
+    /// done on the map — so a coordinate that has no name yet must still report
+    /// that the map has something to show, or the user who has never named
+    /// anything can never get there to start.
+    func testUnnamedCoordinatesStillCountAsLocationData() throws {
+        let habit = TestHelpers.makeHabit()
+        context.insert(habit)
+
+        // A fix with no reverse-geocoded name and no saved Place.
+        let event = TestHelpers.makeEvent(
+            habit: habit,
+            occurredAt: Date(),
+            outcome: "resisted",
+            latitude: 40.7,
+            longitude: -74.0
+        )
+        context.insert(event)
+        try context.save()
+
+        let vm = InsightsViewModel(modelContext: context)
+        vm.selectedTimeRange = .week
+
+        XCTAssertTrue(vm.locationDistribution().isEmpty, "An unnamed coordinate is not a chart row")
+        XCTAssertTrue(vm.hasAnyLocatedEvent, "…but it is still a pin on the map")
+    }
+
+    /// The card's range picker doesn't scope the map, so an old fix outside the
+    /// current range must not read as "no location data".
+    func testLocatedEventOutsideRangeStillCountsAsLocationData() throws {
+        let habit = TestHelpers.makeHabit()
+        context.insert(habit)
+
+        let longAgo = Calendar.current.date(byAdding: .day, value: -90, to: Date())!
+        let event = TestHelpers.makeEvent(
+            habit: habit,
+            occurredAt: longAgo,
+            outcome: "resisted",
+            latitude: 40.7,
+            longitude: -74.0,
+            locationName: "Home"
+        )
+        context.insert(event)
+        try context.save()
+
+        let vm = InsightsViewModel(modelContext: context)
+        vm.selectedTimeRange = .week
+
+        XCTAssertTrue(vm.locationDistribution().isEmpty)
+        XCTAssertTrue(vm.hasAnyLocatedEvent)
+    }
+
+    func testNoLocationDataAtAll() throws {
+        let habit = TestHelpers.makeHabit()
+        context.insert(habit)
+        context.insert(TestHelpers.makeEvent(habit: habit, occurredAt: Date(), outcome: "resisted"))
+        try context.save()
+
+        let vm = InsightsViewModel(modelContext: context)
+        XCTAssertFalse(vm.hasAnyLocatedEvent)
+    }
+
     func testTopLocationReturnsHighestCount() throws {
         let habit = TestHelpers.makeHabit()
         context.insert(habit)

--- a/ResistorTests/TemptationEventTests.swift
+++ b/ResistorTests/TemptationEventTests.swift
@@ -328,4 +328,23 @@ final class TemptationEventTests: XCTestCase {
         XCTAssertNil(event.longitude)
         XCTAssertNil(event.locationName)
     }
+
+    /// The History detail sheet's context rows are one toggle each, so adding a
+    /// tag has to cost the same as removing one and neither may disturb the
+    /// tags already on the event.
+    func testToggleContextTagAddsThenRemoves() {
+        let habit = TestHelpers.makeHabit()
+        let event = TemptationEvent(habit: habit, contextTags: ["Bored"])
+
+        event.toggleContextTag("Stressed")
+        XCTAssertEqual(event.contextTags, ["Bored", "Stressed"])
+
+        event.toggleContextTag("Bored")
+        XCTAssertEqual(event.contextTags, ["Stressed"])
+
+        // Re-adding a removed tag appends rather than duplicating.
+        event.toggleContextTag("Stressed")
+        event.toggleContextTag("Stressed")
+        XCTAssertEqual(event.contextTags, ["Stressed"])
+    }
 }

--- a/ResistorUITests/SnapshotTests.swift
+++ b/ResistorUITests/SnapshotTests.swift
@@ -204,15 +204,26 @@ final class SnapshotTests: XCTestCase {
         // and a hardcoded swipe count silently lands the tap on the wrong card.
         // Not just "visible": the tap lands 60pt *below* the title, so a title
         // sitting near the bottom edge puts the tap past the card entirely —
-        // onto the View Map link, which navigates away. Scroll until the title
-        // is in the top 60% of the screen so the whole plot is on screen too.
+        // onto the next card, whose Top Locations rows navigate away to the map.
+        // Scroll until the title is in the top 60% of the screen so the whole
+        // plot is on screen too.
         let cardTitle = app.staticTexts["Time of Day"]
         func titleIsHighOnScreen() -> Bool {
             cardTitle.exists && cardTitle.isHittable && cardTitle.frame.maxY < app.frame.height * 0.6
         }
-        for _ in 0..<5 where !titleIsHighOnScreen() {
-            scroll.swipeUp(velocity: .slow)
+        func scrollTitleIntoPosition() {
+            // Down first: the card can be *above* the viewport (an expand /
+            // collapse changes its height and shifts everything), and swiping
+            // up from there only pushes it further away.
+            if !titleIsHighOnScreen() {
+                scroll.swipeDown(velocity: .fast)
+                scroll.swipeDown(velocity: .fast)
+            }
+            for _ in 0..<5 where !titleIsHighOnScreen() {
+                scroll.swipeUp(velocity: .slow)
+            }
         }
+        scrollTitleIntoPosition()
 
         // The real expand interaction is a `chartOverlay` spatial-tap hit test
         // on the chart plot. The mirrored accessibility buttons are zero-height
@@ -226,21 +237,26 @@ final class SnapshotTests: XCTestCase {
             XCTFail("Time of Day card never appeared — drill-down capture skipped")
             return
         }
-        let titleFrame = title.frame
-
         // The four period bands run left→right (Morning, Afternoon, Evening,
         // Night) across the card's width; `plotY` sits on the bars, below the
         // title and above the x-axis labels.
+        //
+        // The frame is re-read on every attempt rather than captured once:
+        // expanding the card and collapsing it again changes its height, so a
+        // frame taken before the first tap is stale by the second and the tap
+        // lands 60pt below where the title now is.
         func tapPeriod(dx: CGFloat, named: String) {
-            let plotY = titleFrame.maxY + 60
-            let x = titleFrame.minX + (app.frame.width - titleFrame.minX * 2) * dx
-            app.coordinate(withNormalizedOffset: .zero)
-                .withOffset(CGVector(dx: x, dy: plotY))
-                .tap()
-            XCTAssertTrue(
-                app.buttons["Collapse hourly breakdown"].waitForExistence(timeout: 2),
-                "Tapping the \(named) band did not expand the hourly drill-down"
-            )
+            for _ in 0..<2 {
+                scrollTitleIntoPosition()
+                let frame = title.frame
+                let plotY = frame.maxY + 60
+                let x = frame.minX + (app.frame.width - frame.minX * 2) * dx
+                app.coordinate(withNormalizedOffset: .zero)
+                    .withOffset(CGVector(dx: x, dy: plotY))
+                    .tap()
+                if app.buttons["Collapse hourly breakdown"].waitForExistence(timeout: 2) { return }
+            }
+            XCTFail("Tapping the \(named) band did not expand the hourly drill-down")
         }
 
         // Evening — the simple 4-bar case (3rd of 4 bands).

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,10 +1,15 @@
-No app changes in this build. It is identical to build 34.
+Two changes, both about correcting and exploring what you have already logged.
 
-This build exists to fix how these release notes get delivered. Build 34 shipped
-with "Merge pull request #70 …" here instead of the notes written for it — if you
-saw that, the correct notes have since been restored on build 34, and that is
-where the things worth testing are listed (the Insights habit order, and habit
-descriptions on the Log screen).
+Insights → Top Locations now opens the map. Tap a place to open the map framed on
+it, or tap "Map" in the card's header for every pin. The separate "View Map"
+button below the card is gone. The card also shows when nothing is named yet —
+that was the only way to reach the map to name a first place.
 
-Nothing to test here beyond confirming the app still launches. If you are reading
-this sentence rather than a commit subject, the fix worked.
+History → tap an event: you can now change which habit it was logged against, and
+add or remove context tags, alongside the outcome. Date, time and location stay
+read-only on purpose — they are what the app observed, and the patterns on
+Insights are computed from them.
+
+Worth checking: a location you have never named still gets you to the map; the
+map opens zoomed to the place you tapped; changing an event's habit moves it in
+History and in Insights.

--- a/docs/design.md
+++ b/docs/design.md
@@ -819,14 +819,27 @@ between them reads the selected range.
 - **Time of Day** — bar chart, four periods; a selected period expands in place
   to hourly bars (see Time-of-Day Drill-Down below)
 - **Day of Week** — bar chart
-- **Top Locations** — only when location data exists. A hand-built list (name +
-  count on its own full-width line, bar underneath), not a `Chart` with a
+- **Top Locations** — **always rendered**, named places or not. A hand-built list
+  (name + count on its own full-width line, bar underneath), not a `Chart` with a
   category axis: place names are long enough ("Financial District, San
-  Francisco") that Charts drew the labels inside the plot on top of their own bars
+  Francisco") that Charts drew the labels inside the plot on top of their own bars.
+  This card is the way to the Event Map, with two targets: **a row** pushes the map
+  framed on that place (trailing chevron is the affordance), and the header's
+  **"Map ›"** accessory pushes it unfocused. There is no separate "View Map" link
+  below the card — it asked the user to open an unfocused map and find again the
+  place they were already looking at.
+  **Neither the card nor its "Map" accessory may be gated on there being named
+  places.** A coordinate is logged long before it has a name (the geocode can
+  fail), and naming happens *on the map* — gating strands the user who has never
+  named anything: no rows → no card → no map → no way to ever get a row. Empty
+  copy distinguishes the two cases: "Locations logged, none named yet. Name a spot
+  from the map." vs "No location data yet.", decided by
+  `InsightsViewModel.hasAnyLocatedEvent` over the habit's **whole history** — the
+  map isn't range-scoped, so a 7-day range must not report "no location data" over
+  a map full of pins
 - **Intensity Trend** — only when intensity has been recorded; "Avg {x.x}"
   accessory
 - **Summary** — whole weeks and months from full history; "All time" accessory
-- "View Map" navigation link
 - "View History" navigation link
 
 #### Patterns Card (use cases)
@@ -1212,7 +1225,31 @@ emoji.
 
 - Events grouped by date
 - Swipe to delete
-- Tap for detail sheet — outcome is **editable**; all other fields read-only
+- Tap for detail sheet — **habit, outcome and context tags are editable**; date,
+  time and location stay read-only
+
+#### What the detail sheet lets you correct, and what it doesn't
+
+The editable fields are the ones a user can get *wrong at the moment of logging*
+and know better about afterwards: which habit the urge was for (the wrong card
+on the Log screen), how it went, and the circumstances (context usually comes
+back a moment after the tap).
+
+Date, time and location stay read-only because they are **observations, not
+judgements** — the app recorded when and where the tap happened. Letting either
+be edited turns the log into a diary that can be back-filled, and every pattern
+on Insights is computed from exactly those two fields.
+
+- **Habit** — `.menu` `Picker` over active habits in `Habit.displayOrder`, plus
+  the event's own habit if it has since been archived (a `Picker` whose
+  selection isn't among its options warns and renders blank). "None" is offered
+  only while the event actually has no habit, so a filed event can't be un-filed.
+- **Context** — one row per tag, each toggling on tap (checkmark when set).
+  Every defined `ContextTag` is listed, plus any raw value already on the event
+  that no longer has one (a legacy enum value, or a tag deleted since it was
+  logged) — otherwise the sheet would show a tag it gives no way to remove.
+  A list of what's set plus an editor elsewhere would make adding a tag cost
+  more than removing one.
 
 #### Outcome Correction (use cases)
 
@@ -1241,7 +1278,9 @@ This is the build-ready spec for **Surface C** (the History event-detail picker)
 refines the read-only Outcome `Section` in `EventDetailSheet`
 (`Views/HistoryView.swift:247`). The sheet stays a `.medium`-detent `List`; only the
 Outcome section becomes editable. No other field changes — intensity, context, time,
-location, note rows are untouched.
+location, note rows are untouched. (Superseded in part: habit and context tags are
+editable too now — see "What the detail sheet lets you correct" above. Date, time and
+location are still read-only.)
 
 ##### Picker style
 
@@ -2451,7 +2490,7 @@ as a consequence of logging.**
 | Sheet | Detent | Presented from | Purpose |
 |-------|--------|----------------|---------|
 | Add/Edit Habit | Full | Log toolbar, Habits toolbar, either empty state | Form with color/icon picker |
-| Event Detail | `.medium`, `.large` | History row | Event info; outcome editable, rest read-only |
+| Event Detail | `.medium`, `.large` | History row | Event info; habit, outcome and context tags editable; date/time and location read-only |
 | Place Name | `.medium` | Event Map pin, Event Detail location row | Name/rename/remove the spot |
 | Export (`ShareSheet`) | System | Habits → Data → "Export Data" | System share sheet |
 
@@ -2595,7 +2634,8 @@ User-defined. Managed via the `ContextTag` SwiftData model. Users create and del
 - Outcomes accessory: "{n}% resisted"; empty: "No events in this period"
 - Intensity Trend accessory: "Avg {x.x}"
 - Summary accessory: "All time"; columns "Period", "Events", "Resisted", "Intensity"; "—" where a column has no value
-- "View Map", "View History"
+- Top Locations accessory: "Map" (chevron); empty body: "Locations logged, none named yet. Name a spot from the map." / "No location data yet."
+- "View History"
 
 **Patterns card (Insights):**
 - Card title: "Patterns"


### PR DESCRIPTION
Closes #73. Closes #74.

## Insights → the map

Top Locations rows are now the way onto the Event Map — a row pushes it framed on that place, and a **"Map ›"** accessory in the card header pushes it unfocused. The separate "View Map" link below the card is gone; it opened an unfocused map and asked the user to find again the place they had just tapped past.

**The card renders unconditionally**, which is the part not to "clean up" later. A coordinate is logged long before it carries a name (the reverse geocode can fail), and naming happens *on the map* — gating the card on named places strands exactly the user who has never named anything: no rows → no card → no map → no way to ever get a row.

`InsightsViewModel.hasAnyLocatedEvent` decides the empty copy and reads the habit's **whole history**, not `cachedEventsInRange`: the map isn't range-scoped, so a 7-day range must not report "No location data yet" over a map full of pins.

## History → the event detail sheet

Habit is now a `.menu` Picker (active habits in `Habit.displayOrder`, plus the event's own if archived, so the selection is always among the options), and Context is one toggle row per tag — including any raw value on the event that no longer has a `ContextTag`, or the sheet would show a tag it gives no way to remove.

Date, time and location stay read-only: they are observations rather than judgements, and every pattern on Insights is computed from them.

## Also

`SnapshotTests.captureTimeOfDayDrilldown` read the Time of Day card's frame once and reused it after an expand/collapse had changed the card's height, so the second tap fired 60pt below a stale title. It now re-reads per attempt, scrolls down before up (the card can sit above the viewport), and retries once.

## Verification

Full `Resistor` scheme test action on iPhone 17 Pro: **317 unit + 2 UI tests, 0 failures**. Screenshot harness re-run and read.

New tests: `testUnnamedCoordinatesStillCountAsLocationData`, `testLocatedEventOutsideRangeStillCountsAsLocationData`, `testNoLocationDataAtAll`, `testToggleContextTagAddsThenRemoves`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sdMoCETcfDumJBdarLpba