### PR TITLE
File a temptation logged in a moving vehicle as "In transit"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -604,6 +604,12 @@ intensity ratings, notes, named locations and habit order were device-local and
 would have been lost on any reinstall or new device. All five record types now
 match the models.
 
+`CD_speedMps` (`Double`, no index) was added by hand and deployed on 2026-08-04,
+in the same change that introduced `TemptationEvent.speedMps` — an optional
+never populated on a dev build, so exactly the case where "Deploy Schema
+Changes" has nothing to find until someone creates the field. `CD_TemptationEvent`
+is 18 fields in both environments.
+
 When adding a field by hand, take its type from a sibling SwiftData already
 generated rather than guessing: `Int`/`Int?`/`Bool` → `Int(64)`, `String?` →
 `String`, `Double?` → `Double`, `[String]` → `Bytes`, `Date` → `Date/Time`.

--- a/Resistor/Models/Place.swift
+++ b/Resistor/Models/Place.swift
@@ -35,6 +35,10 @@ final class Place {
     /// someone needs a campus or a mall covered.
     static let matchRadius: CLLocationDistance = 150
 
+    /// What an event logged in a moving vehicle is called instead of a place.
+    /// Not a `Place` row — nothing is saved, and no coordinate owns it.
+    static let transitName = "In transit"
+
     var coordinate: CLLocationCoordinate2D {
         CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
     }
@@ -54,13 +58,18 @@ extension Collection where Element == Place {
     /// What to show the user for an event's location: its saved place name, else
     /// the reverse-geocoded name, else raw coordinates.
     func displayName(for event: TemptationEvent) -> String? {
-        match(event)?.name ?? event.locationDisplayName
+        if event.isInTransit { return Place.transitName }
+        return match(event)?.name ?? event.locationDisplayName
     }
 
     /// Grouping key for Insights: saved place name, else the reverse-geocoded
     /// name. Raw coordinates are deliberately excluded — a lat/lon pair is not a
     /// place the user would recognize in a chart.
     func groupingName(for event: TemptationEvent) -> String? {
+        // Ahead of the coordinate check below: unlike a lat/lon pair, "In
+        // transit" is a name the user recognizes, so a moving event still
+        // groups even when the geocode came back empty.
+        if event.isInTransit { return Place.transitName }
         if let place = match(event) { return place.name }
         guard let name = event.locationName, !name.isEmpty else { return nil }
         return name

--- a/Resistor/Models/TemptationEvent.swift
+++ b/Resistor/Models/TemptationEvent.swift
@@ -13,6 +13,10 @@ final class TemptationEvent {
     var latitude: Double?
     var longitude: Double?
     var locationName: String?
+    /// Metres per second at the moment of the fix, or nil when the fix couldn't
+    /// supply one. Stored raw rather than as a flag so `transitSpeed` can be
+    /// retuned without a migration — and CloudKit fields can never be removed.
+    var speedMps: Double?
 
     var habit: Habit?
 
@@ -26,7 +30,8 @@ final class TemptationEvent {
         note: String? = nil,
         latitude: Double? = nil,
         longitude: Double? = nil,
-        locationName: String? = nil
+        locationName: String? = nil,
+        speedMps: Double? = nil
     ) {
         self.id = id
         self.habit = habit
@@ -38,6 +43,7 @@ final class TemptationEvent {
         self.latitude = latitude
         self.longitude = longitude
         self.locationName = locationName
+        self.speedMps = speedMps
     }
 }
 
@@ -152,6 +158,26 @@ extension TemptationEvent {
 
     var hasLocation: Bool {
         latitude != nil && longitude != nil
+    }
+
+    /// Above this the fix came from a vehicle rather than a place. The
+    /// coordinate is then a road the user was passing, so matching it against a
+    /// saved `Place` — or even against the geocoded neighbourhood — files the
+    /// event somewhere it never really happened, and puts that noise into
+    /// `PatternFinder`'s place facet and Insights' Top Locations.
+    ///
+    /// ponytail: one threshold, 5 m/s (~11 mph), which also catches a cyclist.
+    /// Split it per travel mode if "In transit" ever has to say which.
+    static let transitSpeed: Double = 5
+
+    /// `CLLocation.speed` is negative when the fix can't derive one — common at
+    /// `kCLLocationAccuracyHundredMeters`, where a fix may come from wifi or
+    /// cell. That is stored as nil, and an unknown speed reads as stationary:
+    /// the old behaviour, which is also what every event logged before this
+    /// field existed gets.
+    var isInTransit: Bool {
+        guard let speedMps else { return false }
+        return speedMps >= Self.transitSpeed
     }
 
     var locationDisplayName: String? {

--- a/Resistor/Services/DataExporter.swift
+++ b/Resistor/Services/DataExporter.swift
@@ -33,6 +33,7 @@ enum DataExporter {
             dict["latitude"] = event.latitude ?? NSNull()
             dict["longitude"] = event.longitude ?? NSNull()
             dict["location_name"] = event.locationName ?? NSNull()
+            dict["speed_mps"] = event.speedMps ?? NSNull()
             return dict
         }
 

--- a/Resistor/Services/LocationManager.swift
+++ b/Resistor/Services/LocationManager.swift
@@ -36,6 +36,11 @@ extension LocationProviding {
 
         event.latitude = location.coordinate.latitude
         event.longitude = location.coordinate.longitude
+        // Negative means the fix couldn't derive a speed. Store nil rather than
+        // the sentinel, so "moving slowly" and "don't know" stay distinct.
+        event.speedMps = location.speed >= 0 ? location.speed : nil
+        // Geocode even when moving: the name is still worth keeping, since
+        // `transitSpeed` decides at display time and can change.
         if let placeName {
             event.locationName = placeName
         }

--- a/Resistor/Views/HistoryView.swift
+++ b/Resistor/Views/HistoryView.swift
@@ -401,21 +401,33 @@ struct EventDetailSheet: View {
                 // Location section
                 if event.hasLocation {
                     Section("Location") {
-                        Button {
-                            showPlaceNameSheet = true
-                        } label: {
+                        if event.isInTransit {
+                            // No naming affordance: the coordinate is a road the
+                            // user was passing, so a name saved here would never
+                            // show on this event — the display stays "In
+                            // transit" — and offering "Name" would read as broken.
                             HStack(spacing: 8) {
-                                Image(systemName: "location.fill")
+                                Image(systemName: "car.fill")
                                     .foregroundStyle(.secondary)
-                                Text(places.displayName(for: event) ?? "Unknown")
-                                    .foregroundStyle(.primary)
-                                Spacer()
-                                Text(places.match(event) == nil ? "Name" : "Rename")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
+                                Text(Place.transitName)
                             }
+                        } else {
+                            Button {
+                                showPlaceNameSheet = true
+                            } label: {
+                                HStack(spacing: 8) {
+                                    Image(systemName: "location.fill")
+                                        .foregroundStyle(.secondary)
+                                    Text(places.displayName(for: event) ?? "Unknown")
+                                        .foregroundStyle(.primary)
+                                    Spacer()
+                                    Text(places.match(event) == nil ? "Name" : "Rename")
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .accessibilityHint("Double tap to name this place.")
                         }
-                        .accessibilityHint("Double tap to name this place.")
 
                         if let lat = event.latitude, let lon = event.longitude {
                             Map(initialPosition: .region(MKCoordinateRegion(

--- a/ResistorTests/PlaceTests.swift
+++ b/ResistorTests/PlaceTests.swift
@@ -99,6 +99,61 @@ final class PlaceTests: XCTestCase {
         XCTAssertNil([Place]().groupingName(for: event))
     }
 
+    // MARK: - In transit
+
+    func testTransitBeatsASavedPlaceTheEventDrovePast() {
+        let home = Place(name: "Home", latitude: base.lat, longitude: base.lon)
+        let habit = TestHelpers.makeHabit()
+        let event = TestHelpers.makeEvent(
+            habit: habit,
+            latitude: within,
+            longitude: base.lon,
+            locationName: "Midtown, New York",
+            speedMps: 20   // ~45 mph
+        )
+
+        // Driving past the house is not being at the house — the whole point of
+        // the field. It has to win over both the saved place and the geocode.
+        XCTAssertEqual([home].displayName(for: event), "In transit")
+        XCTAssertEqual([home].groupingName(for: event), "In transit")
+    }
+
+    func testTransitGroupsEvenWithoutAGeocodedName() {
+        let habit = TestHelpers.makeHabit()
+        let event = TestHelpers.makeEvent(
+            habit: habit,
+            latitude: base.lat,
+            longitude: base.lon,
+            speedMps: 20
+        )
+
+        // Raw coordinates are excluded from the grouping key; "In transit" is a
+        // name, so it must not be dropped alongside them.
+        XCTAssertEqual([Place]().groupingName(for: event), "In transit")
+    }
+
+    func testWalkingPaceAndUnknownSpeedBothStayAtThePlace() {
+        let home = Place(name: "Home", latitude: base.lat, longitude: base.lon)
+        let habit = TestHelpers.makeHabit()
+        let strolling = TestHelpers.makeEvent(
+            habit: habit,
+            latitude: within,
+            longitude: base.lon,
+            speedMps: 1.5   // walking
+        )
+        // nil is what a wifi or cell fix stores, and what every event logged
+        // before the field existed has. It must read as stationary, not as
+        // transit, or the whole back catalogue relabels itself.
+        let unknown = TestHelpers.makeEvent(
+            habit: habit,
+            latitude: within,
+            longitude: base.lon
+        )
+
+        XCTAssertEqual([home].displayName(for: strolling), "Home")
+        XCTAssertEqual([home].displayName(for: unknown), "Home")
+    }
+
     // MARK: - Insights grouping
 
     func testNamedPlacesSplitAnIdenticalGeocodedString() throws {

--- a/ResistorTests/TestHelpers.swift
+++ b/ResistorTests/TestHelpers.swift
@@ -38,7 +38,8 @@ enum TestHelpers {
         note: String? = nil,
         latitude: Double? = nil,
         longitude: Double? = nil,
-        locationName: String? = nil
+        locationName: String? = nil,
+        speedMps: Double? = nil
     ) -> TemptationEvent {
         TemptationEvent(
             habit: habit,
@@ -49,7 +50,8 @@ enum TestHelpers {
             note: note,
             latitude: latitude,
             longitude: longitude,
-            locationName: locationName
+            locationName: locationName,
+            speedMps: speedMps
         )
     }
 

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,15 +1,24 @@
-Two changes, both about correcting and exploring what you have already logged.
+One change, about where a temptation logged in a moving vehicle gets filed.
 
-Insights → Top Locations now opens the map. Tap a place to open the map framed on
-it, or tap "Map" in the card's header for every pin. The separate "View Map"
-button below the card is gone. The card also shows when nothing is named yet —
-that was the only way to reach the map to name a first place.
+Until now a log made while driving was recorded at whatever coordinate the fix
+landed on, so it was filed under a neighbourhood you were only passing through —
+or matched to a place you had named, if you happened to drive within 150 m of it.
+Those events now read "In transit" instead: in History, on the map, in Insights →
+Top Locations, and in the Patterns card.
 
-History → tap an event: you can now change which habit it was logged against, and
-add or remove context tags, alongside the outcome. Date, time and location stay
-read-only on purpose — they are what the app observed, and the patterns on
-Insights are computed from them.
+The threshold is about 11 mph, so walking and standing still are unaffected. An
+event logged in transit has no spot to name, so its History detail shows the
+location without the Name / Rename option.
 
-Worth checking: a location you have never named still gets you to the map; the
-map opens zoomed to the place you tapped; changing an event's habit moves it in
-History and in Insights.
+Nothing already logged changes. Speed is read from the location fix at the moment
+you log, and events recorded before this build carry none, so they keep their
+current location exactly as it is.
+
+Worth checking: log one as a passenger on a drive and confirm it reads "In
+transit" rather than a street or a named place; log one while walking and confirm
+it still names the place; confirm your existing history is unchanged.
+
+Known unknown, and the useful thing to report: some location fixes cannot supply
+a speed at all — a fix from wifi or cell rather than GPS. Those are treated as
+stationary. If you log while clearly driving and it still shows a place name,
+that is the case worth telling us about.


### PR DESCRIPTION
Closes #76.

A craving logged while driving was recorded at whatever coordinate the fix landed on, so it was filed under a neighbourhood the user was only passing through — or matched to a saved `Place` they happened to drive within 150 m of. Both are noise in a real facet: they dilute `PatternFinder`'s place dimension and put a meaningless row in Insights' Top Locations. "In transit" is the honest answer, and it is a signal in its own right.

## What changed

- **`TemptationEvent.speedMps: Double?`** + `isInTransit`, threshold `transitSpeed` = 5 m/s (~11 mph). `CLLocation.speed` was already on the fix `LocationProviding.attachLocation(to:in:)` takes and discarded.
- **`Place.displayName` / `groupingName`** short-circuit to `Place.transitName`.
- **History detail** drops the Name/Rename affordance for an in-transit event.
- **Export** gains `speed_mps`.
- **CLAUDE.md** schema note updated; **TestFlight notes** hand-written.

## Decisions worth reviewing

**Not a new `PatternFinder.Facet` case — a new *value* of `.place`.** Patterns, Top Locations, the Event Map and History rows all pick it up with zero edits. A `.transit` facet would have needed ~8 switch sites, a summary template, and a slice of the multiple-comparison budget that `p <= 0.01` is sized for, to say something the place axis can already say.

**In `groupingName` the check sits ahead of the raw-coordinate exclusion.** A lat/lon pair is dropped from the grouping key because it is not a name a user recognizes; "In transit" is. So a moving event still groups even when the geocode came back empty. Pinned by `testTransitGroupsEvenWithoutAGeocodedName`.

**Speed stored raw, not as a flag.** The threshold can be retuned without a migration — and a CloudKit field can never be removed, so the flag would have been permanent. Negative speed (the fix could not derive one — common at `kCLLocationAccuracyHundredMeters`, where a fix may come from wifi or cell) stores as nil and reads as stationary, which is also what every pre-existing event gets. `testWalkingPaceAndUnknownSpeedBothStayAtThePlace` pins that the back catalogue does not relabel itself.

**History drops the naming affordance; the map keeps it.** A name saved against an in-transit event could never show on it — the display stays "In transit" — so a row offering "Name" reads as broken. On the map, suppressing the button would leave a silently dead pin under a hint that says to tap one, which is worse; the `Place` it creates is still useful for stationary events nearby.

## CloudKit

`CD_speedMps` (`Double`, no index, per the sibling `CD_latitude`/`CD_longitude`) **is already added to Development and deployed to Production** — verified in the Console, `CD_TemptationEvent` is 18 fields in both environments. So this does not ship a field that silently fails to sync for TestFlight users.

## Verification

- `xcodebuild test -scheme Resistor -only-testing:ResistorTests` — **320 tests, 0 failures**, including 3 new ones in `PlaceTests`.
- `ResistorWatch` builds (`LocationManager` is shared with the watch target, which gets the capture for free).

## Not verified, and only a device can

Whether `CLLocation.speed` is actually valid at this app's accuracy setting during a real drive. If it mostly reads negative, the fallback is `CMMotionActivity` (`.automotive`) — a separate framework and an `NSMotionUsageDescription` prompt. The TestFlight notes ask testers for exactly this case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sdMoCETcfDumJBdarLpba