### PR TITLE
Suggest place names from nearby businesses and Contacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,25 @@ Named from `PlaceNameSheet`, reachable two ways — tap a pin on the Event Map, 
 tap the Location row in a History event's detail. There is no manage-places list
 in Settings; a place is renamed or removed through the same sheet.
 
+**The sheet suggests names; it never applies one.** Three sources fill the text
+field — businesses at the coordinate (`MKLocalPointsOfInterestRequest`, radius
+`Place.matchRadius`, so a POI outside what a saved place would cover is never
+offered), names already in use, and the address book. Auto-picking the nearest
+POI is the same wrong answer with a more authoritative name: a
+`kCLLocationAccuracyHundredMeters` fix in a strip mall has a dozen candidates,
+and unlike a blank it enters `PatternFinder` as a confident facet. The user
+confirming is what `Place` was designed around.
+
+`ContactNamePicker` wraps `CNContactPickerViewController`, which runs **out of
+process** — no `CNContactStore` authorization, no permission prompt, no privacy
+label, and the delegate is handed only the contact that was tapped. Only its
+name string is read; the place still saves at the *event's* coordinate, so no
+postal address is touched and nothing is forward-geocoded. Keep it that way:
+matching contacts by address (issue #78 Stage B) buys one tap and costs full
+address-book permission plus a geocode per contact. Its `onPick` fires on cancel
+too, with nil — the picker dismisses itself, so a SwiftUI `isPresented` left true
+would strand the sheet closed-but-presented and it could never reopen.
+
 ### UserSettings
 
 | Field | Type | Notes |

--- a/Resistor/Views/PlaceNameSheet.swift
+++ b/Resistor/Views/PlaceNameSheet.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import SwiftData
+import MapKit
+import Contacts
+import ContactsUI
 
 /// Assigns a short name to the spot where an event was logged. Saving writes a
 /// `Place` at the event's coordinate; every event within `Place.matchRadius` of
@@ -14,6 +17,8 @@ struct PlaceNameSheet: View {
 
     @State private var name: String = ""
     @State private var didLoad = false
+    @State private var nearby: [String] = []
+    @State private var showContactPicker = false
 
     /// The place already covering this spot. Editing renames it rather than
     /// stacking a second place on the same coordinate.
@@ -46,8 +51,22 @@ struct PlaceNameSheet: View {
                         .autocorrectionDisabled()
                         .submitLabel(.done)
                         .onSubmit(save)
+
+                    Button {
+                        showContactPicker = true
+                    } label: {
+                        Label("From Contacts", systemImage: "person.crop.circle")
+                    }
                 } footer: {
                     Text("Events logged within \(radiusText) of here show this name.")
+                }
+
+                if !nearby.isEmpty {
+                    Section("Nearby") {
+                        ForEach(nearby, id: \.self) { poi in
+                            Button(poi) { name = poi }
+                        }
+                    }
                 }
 
                 if !suggestions.isEmpty {
@@ -80,8 +99,45 @@ struct PlaceNameSheet: View {
                 name = existing?.name ?? ""
                 didLoad = true
             }
+            .task { await loadNearby() }
+            .sheet(isPresented: $showContactPicker) {
+                ContactNamePicker { picked in
+                    if let picked, !picked.isEmpty { name = picked }
+                    showContactPicker = false
+                }
+            }
         }
         .presentationDetents([.medium])
+    }
+
+    /// Businesses at the event's coordinate, offered as one-tap fills. Searched
+    /// within `Place.matchRadius` because that is exactly the spread a saved
+    /// place covers — a POI further out is not the place this event resolves to.
+    ///
+    /// Suggested, never auto-applied: at `kCLLocationAccuracyHundredMeters` a
+    /// strip mall holds a dozen candidates, and a wrong POI is worse than none
+    /// because it enters `PatternFinder` as a confident facet.
+    private func loadNearby() async {
+        guard !event.isInTransit,
+              let lat = event.latitude,
+              let lon = event.longitude else { return }
+        let request = MKLocalPointsOfInterestRequest(
+            center: CLLocationCoordinate2D(latitude: lat, longitude: lon),
+            radius: Place.matchRadius
+        )
+        guard let response = try? await MKLocalSearch(request: request).start() else { return }
+        nearby = Self.nearbyNames(from: response.mapItems.map(\.name))
+    }
+
+    /// Deduped and capped, split out from the search so the filtering is
+    /// testable without MapKit.
+    static func nearbyNames(from raw: [String?], limit: Int = 6) -> [String] {
+        var seen = Set<String>()
+        return Array(
+            raw.compactMap { $0 }
+                .filter { !$0.isEmpty && seen.insert($0).inserted }
+                .prefix(limit)
+        )
     }
 
     private func save() {
@@ -104,5 +160,52 @@ struct PlaceNameSheet: View {
             try? modelContext.save()
         }
         dismiss()
+    }
+}
+
+// MARK: - Contact Picker
+
+/// Fills the name field from the address book — a place is often a person's
+/// ("Mom", "Dave").
+///
+/// `CNContactPickerViewController` runs out of process, so this needs **no**
+/// `CNContactStore` authorization, no permission prompt and no privacy-label
+/// change: the delegate is handed only the one contact the user tapped. Only
+/// the name string is read — `Place` stores the event's own coordinate, so no
+/// postal address is touched and nothing is geocoded.
+///
+/// `onPick` fires for cancel too, with nil, because the picker dismisses itself
+/// and SwiftUI's `isPresented` would otherwise stay true over a dismissed
+/// controller — the sheet could never be opened again.
+private struct ContactNamePicker: UIViewControllerRepresentable {
+    let onPick: (String?) -> Void
+
+    func makeUIViewController(context: Context) -> CNContactPickerViewController {
+        let picker = CNContactPickerViewController()
+        picker.delegate = context.coordinator
+        // A name is the only thing taken, so a contact without one is inert.
+        picker.predicateForEnablingContact = NSPredicate(
+            format: "givenName.length > 0 OR familyName.length > 0 OR organizationName.length > 0"
+        )
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: CNContactPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(onPick: onPick) }
+
+    final class Coordinator: NSObject, CNContactPickerDelegate {
+        private let onPick: (String?) -> Void
+
+        init(onPick: @escaping (String?) -> Void) { self.onPick = onPick }
+
+        func contactPicker(_ picker: CNContactPickerViewController, didSelect contact: CNContact) {
+            let name = CNContactFormatter.string(from: contact, style: .fullName)
+            onPick(name?.isEmpty == false ? name : contact.organizationName)
+        }
+
+        func contactPickerDidCancel(_ picker: CNContactPickerViewController) {
+            onPick(nil)
+        }
     }
 }

--- a/ResistorTests/PlaceTests.swift
+++ b/ResistorTests/PlaceTests.swift
@@ -229,4 +229,16 @@ final class PlaceTests: XCTestCase {
             ["12 PM", "1", "2", "3", "4"]
         )
     }
+
+    // MARK: - Nearby name suggestions
+
+    func testNearbyNamesDropNilsAndDuplicatesAndCap() {
+        let raw: [String?] = ["Blue Bottle", nil, "Blue Bottle", "", "Safeway", "Gym", "Bank", "Park", "Deli", "Bar"]
+        // First-seen order kept, so the closest result stays at the top.
+        XCTAssertEqual(
+            PlaceNameSheet.nearbyNames(from: raw),
+            ["Blue Bottle", "Safeway", "Gym", "Bank", "Park", "Deli"]
+        )
+        XCTAssertEqual(PlaceNameSheet.nearbyNames(from: raw, limit: 2), ["Blue Bottle", "Safeway"])
+    }
 }

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,24 +1,25 @@
-One change, about where a temptation logged in a moving vehicle gets filed.
+Naming a place no longer has to be typing.
 
-Until now a log made while driving was recorded at whatever coordinate the fix
-landed on, so it was filed under a neighbourhood you were only passing through —
-or matched to a place you had named, if you happened to drive within 150 m of it.
-Those events now read "In transit" instead: in History, on the map, in Insights →
-Top Locations, and in the Patterns card.
+Open the Name This Place sheet — tap a pin on the Event Map, or the Location row
+in a History event's detail — and it now offers the names of businesses at that
+coordinate as one-tap fills, under "Nearby". There is also a "From Contacts"
+button, for the places that are a person's rather than a business: it opens the
+system contact picker and fills the field with the name you tap.
 
-The threshold is about 11 mph, so walking and standing still are unaffected. An
-event logged in transit has no spot to name, so its History detail shows the
-location without the Name / Rename option.
+Nothing is applied for you. A hundred-metre fix in a strip mall has a dozen
+plausible answers, and a confidently wrong one is worse than none, because a
+place name feeds Insights and the Patterns card. The suggestions fill the text
+field; you still confirm with Save, and you can still type anything.
 
-Nothing already logged changes. Speed is read from the location fix at the moment
-you log, and events recorded before this build carry none, so they keep their
-current location exactly as it is.
+The contact picker asks for no permission and reads no addresses. It runs
+outside the app and hands back only the name of the contact you tapped — the
+place is still saved at the event's own coordinate.
 
-Worth checking: log one as a passenger on a drive and confirm it reads "In
-transit" rather than a street or a named place; log one while walking and confirm
-it still names the place; confirm your existing history is unchanged.
+Worth checking: open the sheet somewhere with businesses around and confirm the
+Nearby list is plausible; confirm "From Contacts" opens the picker without a
+permission prompt and fills the field; confirm an event logged in transit still
+offers no naming at all.
 
-Known unknown, and the useful thing to report: some location fixes cannot supply
-a speed at all — a fix from wifi or cell rather than GPS. Those are treated as
-stationary. If you log while clearly driving and it still shows a place name,
-that is the case worth telling us about.
+The useful thing to report: a Nearby list that is empty or obviously wrong where
+you would expect a business, and whether the contact picker ever prompts for
+address-book access.


### PR DESCRIPTION
Closes #78 (Stage A).

Naming a place was typing. `PlaceNameSheet` now offers fills.

- **Nearby** — `MKLocalPointsOfInterestRequest` at the event coordinate, radius `Place.matchRadius`. Same radius by construction: a POI outside what a saved place would cover is not the place this event resolves to. Deduped, capped at 6.
- **From Contacts** — `CNContactPickerViewController`. Out-of-process, so no `CNContactStore` authorization, no permission prompt, no privacy label. Only the name string is read; the place still saves at the event's own coordinate.

**Suggested, never auto-applied.** A hundred-metre fix in a strip mall has a dozen candidates, and a confidently wrong name is worse than a blank — it enters `PatternFinder` as a facet and Insights as a Top Location.

In-transit events are skipped, matching `HistoryView`, which already offers no naming for a road you were passing.

### Not built
Stage B (opt-in address-book pre-matching) — buys one tap over the picker, costs full Contacts permission, a privacy label and a rate-limited forward-geocode per contact. The issue itself says ship A first.

Extra entry points ("more ways in") — the map pin and the History detail row already reach the sheet in two taps; adding a third path is surface for a case the sheet now handles faster. Say the word if you want a History-row swipe action.

### Verification
`BUILD SUCCEEDED`, `ResistorTests/PlaceTests` passes including the new `testNearbyNamesDropNilsAndDuplicatesAndCap`.

Not verified on device: that the contact picker genuinely never prompts (out-of-process behaviour is documented, not observed here) and that Nearby returns sensible POIs against a real fix. Both are in the TestFlight notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sdMoCETcfDumJBdarLpba