### PR TITLE
Contact matching for place names, and a third way into the naming sheet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,10 +22,12 @@ Resistor/
 │   ├── TemptationEvent.swift         # @Model — logged event entity
 │   ├── UserSettings.swift            # @Model — singleton settings
 │   ├── ContextTag.swift              # @Model — user-defined context tag
-│   └── Place.swift                   # @Model — user-named location + distance matching
+│   ├── Place.swift                   # @Model — user-named location + distance matching
+│   └── ContactPlace.swift            # @Model — geocoded contact address, device-local cache
 ├── Services/
 │   ├── DataExporter.swift            # CSV/JSON export of temptation events
 │   ├── LocationManager.swift         # GPS location capture for events
+│   ├── ContactMatcher.swift          # Opt-in address-book geocoding → ContactPlace
 │   └── PatternFinder.swift           # Trigger detection — see "Pattern Detection"
 ├── ViewModels/
 │   ├── LogViewModel.swift            # Log screen logic + Core Haptics engine
@@ -162,9 +164,49 @@ Duplicate names are allowed on purpose: a drifting fix or a site with two
 entrances is covered by saving a second `Place` with the same name, and display
 groups by name.
 
-Named from `PlaceNameSheet`, reachable two ways — tap a pin on the Event Map, or
-tap the Location row in a History event's detail. There is no manage-places list
-in Settings; a place is renamed or removed through the same sheet.
+Named from `PlaceNameSheet`, reachable three ways — tap a pin on the Event Map,
+tap the Location row in a History event's detail, or swipe a History row from the
+**leading** edge. The swipe appears only when `canName` holds (located, not in
+transit, no `Place` matching yet), so it is offered exactly when the row is
+showing the fallback the name would replace; the trailing edge stays Delete's,
+because that is the edge a full swipe fires. There is no manage-places list in
+Settings; a place is renamed or removed through the same sheet.
+
+**The sheet suggests names; it never applies one.** Three sources fill the text
+field — businesses at the coordinate (`MKLocalPointsOfInterestRequest`, radius
+`Place.matchRadius`, so a POI outside what a saved place would cover is never
+offered), names already in use, and Contacts. Auto-picking the nearest POI is the
+same wrong answer with a more authoritative name: a
+`kCLLocationAccuracyHundredMeters` fix in a strip mall has a dozen candidates,
+and unlike a blank it enters `PatternFinder` as a confident facet. The user
+confirming is what `Place` was designed around.
+
+Contacts arrive two ways, and the cheap one is not the fallback for the
+expensive one — they answer different questions:
+
+- **`ContactNamePicker`** wraps `CNContactPickerViewController`, which runs **out
+  of process**: no `CNContactStore` authorization, no prompt, no privacy label,
+  and the delegate is handed only the contact that was tapped. Always available.
+  Its `onPick` fires on cancel too, with nil — the picker dismisses itself, so a
+  SwiftUI `isPresented` left true would strand the sheet closed-but-presented and
+  it could never reopen.
+- **`ContactMatcher` + `ContactPlace`** (opt-in, from Settings › Contacts) geocode
+  the address book once so a contact's name appears *without* picking a source.
+  That is the only thing it buys, and it costs full Contacts access, a privacy
+  label and a rate-limited geocode per contact — hence a button the user presses,
+  never anything automatic. Only the name string is read either way; the place
+  still saves at the *event's* coordinate, so no postal address is stored and
+  nothing is forward-geocoded onto an event.
+
+`ContactPlace` is **not** a `Place` despite the identical shape, and it lives in
+its own `cloudKitDatabase: .none` store — see "The store lives in the App Group"
+below.
+
+Settings shows an action and a resting state ("Match My Contacts" / "Matched — N
+contacts" + Remove), **not a `Toggle`**: a toggle would have to flip itself back
+off whenever a run matched nothing — access declined, or no contact has an
+address — which reads as a broken switch. Nothing here is a setting; either
+matches exist or they don't.
 
 **The sheet suggests names; it never applies one.** Three sources fill the text
 field — businesses at the coordinate (`MKLocalPointsOfInterestRequest`, radius
@@ -563,6 +605,33 @@ iCloud sync via SwiftData + CloudKit imposes these restrictions:
 - **No ordered relationships** — sort at query time
 - **No cascading deletes** — implement manually (see above)
 - **Additive-only schema migrations** — cannot rename or remove fields once shipped
+
+### Two configurations: the synced store, and a device-local cache
+
+`SharedModelContainer` opens **one container over two `ModelConfiguration`s**.
+`cloudSchema` (Habit, TemptationEvent, UserSettings, ContextTag, Place) is the
+user's data and mirrors to CloudKit. `localSchema` is `ContactPlace` alone, in
+its own `ContactPlaces.store` with `cloudKitDatabase: .none`. `schema` is the
+union, because `ModelContainer(for:)` has to cover every configuration.
+
+Three things fall out of keeping the contact cache local, and all three are the
+point:
+
+- **No postal address ever leaves the phone.** It is geocoded from Contacts,
+  which the user's devices already sync themselves — mirroring it again would put
+  the address book in the app's CloudKit database for nothing.
+- **No `CD_ContactPlace` to deploy.** A new synced `@Model` is a Production record
+  type someone has to create by hand and deploy before it works for a TestFlight
+  user (see below); a local one is live the moment it builds.
+- The cost is a rebuild per device, which is exactly the Settings button that
+  created it. `ContactPlace` is derived and disposable — that is why an empty one
+  after a reinstall is a tap, not data loss, and why the local store gets no
+  migration path of the kind the main store needed.
+
+`testCloudAndLocalConfigurationsOpenAsOneContainer` and
+`testContactCacheIsNotInTheCloudSchema` pin both halves. A bad split does not
+fail to compile — `ModelContainer` throws at launch and the app `fatalError`s on
+it — and the leak back into `cloudSchema` would be silent and permanent.
 
 ### The store lives in the App Group, and moving there is a migration
 

--- a/Resistor.xcodeproj/project.pbxproj
+++ b/Resistor.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		18A195F9B7925BB56D429711 /* ResistorWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DF18F3D313F229C82C59743E /* ResistorWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1EA2AB1E243FA4FF3695A153 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D550B62AA43FA6F8E07A3859 /* Foundation.framework */; };
 		2E5B76D51971E96AB65B64CF /* Place.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E8F37DF17C48226C946BF9 /* Place.swift */; };
+		2EB7D9796333E9B0D1CEDD6E /* ContactPlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF317A8D62ACC245811E825 /* ContactPlace.swift */; };
 		3CCC347E1657F5C34088D7DB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A100000F000000000000000A /* Assets.xcassets */; };
 		3EB933B6532E4FB909C64487 /* QuickLogWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E111D234A6D4D52B3C29F28 /* QuickLogWidgetView.swift */; };
 		400E7DE395ECA6EA4C1D3F9E /* LogResistedIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA4656BDF208C2526724BEB /* LogResistedIntent.swift */; };
@@ -30,6 +31,7 @@
 		6338F6467C5189388ECC395C /* ContextTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1000001000000000000000A /* ContextTag.swift */; };
 		6AD46C3EBEED5D591162E51E /* WatchLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D3AB0EA799474A518E40CE /* WatchLogStore.swift */; };
 		6B8626F4730E92DF4F21C2C8 /* Place.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E8F37DF17C48226C946BF9 /* Place.swift */; };
+		6F371D3B6BC196A4F7FC48C6 /* ContactPlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF317A8D62ACC245811E825 /* ContactPlace.swift */; };
 		74814CEC0773B750D5E8971D /* ResistorWatchComplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABA9A53B23917079FC676D9 /* ResistorWatchComplication.swift */; };
 		77053A802CD8451E81504253 /* HabitAppEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39097DA98DAC5F5C22FA4BD3 /* HabitAppEntity.swift */; };
 		8132D3C8C3A433BC0731783F /* ResistorWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32E0160D608ABC8D400DB5F /* ResistorWatchApp.swift */; };
@@ -84,6 +86,7 @@
 		CC9B3EE69FC6CED9DA5C375D /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34ABD48A949E05238016CBF /* SharedModelContainer.swift */; };
 		D354EB66006655563DFD61FB /* UITestSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A986130363EAECA937D1B7 /* UITestSeed.swift */; };
 		D4CBA1C324611D3CB789BE3E /* SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7A220FBBC346EEC2773BB4 /* SnapshotTests.swift */; };
+		D830477B0140A2278C952D21 /* ContactMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE84428F28D914F2F000DC4C /* ContactMatcher.swift */; };
 		DB24B141241DF326D4B0E457 /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34ABD48A949E05238016CBF /* SharedModelContainer.swift */; };
 		DDE9B5D235853D45E9B21BCD /* ResistorWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C931270813D632B915D37D59 /* ResistorWidgetBundle.swift */; };
 		E9EDE74E8B6B57BC689F9C14 /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000D000000000000000A /* UserSettings.swift */; };
@@ -179,6 +182,7 @@
 		43CA41D02F89724100D11E7D /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		43CA41D22F89730100D11E7D /* EventMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMapView.swift; sourceTree = "<group>"; };
 		49F792C9FFECBD4172FA9C25 /* ResistorWidget.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = ResistorWidget.entitlements; sourceTree = "<group>"; };
+		5FF317A8D62ACC245811E825 /* ContactPlace.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactPlace.swift; sourceTree = "<group>"; };
 		656E85A95F778C45397ECA90 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6F4A323D24B5922D97906FD1 /* ResistorWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResistorWidget.swift; sourceTree = "<group>"; };
 		7D4597E26EF41C66F2BAD61A /* WatchLogView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchLogView.swift; sourceTree = "<group>"; };
@@ -233,6 +237,7 @@
 		B2000099000000000000000A /* TimeOfDayDrillDownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeOfDayDrillDownTests.swift; sourceTree = "<group>"; };
 		B200009A000000000000000A /* WatchLogStoreLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchLogStoreLogicTests.swift; sourceTree = "<group>"; };
 		B20000FF000000000000000A /* OnboardingGatingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingGatingTests.swift; sourceTree = "<group>"; };
+		BE84428F28D914F2F000DC4C /* ContactMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactMatcher.swift; sourceTree = "<group>"; };
 		C1000001000000000000000A /* ContextTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextTag.swift; sourceTree = "<group>"; };
 		C1880531AD4D2C420470F188 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS11.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		C931270813D632B915D37D59 /* ResistorWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResistorWidgetBundle.swift; sourceTree = "<group>"; };
@@ -426,6 +431,7 @@
 				A100000D000000000000000A /* UserSettings.swift */,
 				C1000001000000000000000A /* ContextTag.swift */,
 				03E8F37DF17C48226C946BF9 /* Place.swift */,
+				5FF317A8D62ACC245811E825 /* ContactPlace.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -472,6 +478,7 @@
 				A1000015000000000000000B /* PatternFinder.swift */,
 				43CA41D02F89724100D11E7D /* LocationManager.swift */,
 				E7A986130363EAECA937D1B7 /* UITestSeed.swift */,
+				BE84428F28D914F2F000DC4C /* ContactMatcher.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -725,6 +732,7 @@
 				DB24B141241DF326D4B0E457 /* SharedModelContainer.swift in Sources */,
 				8C41ECC1C5222C46E02AACD8 /* TemptationLogger.swift in Sources */,
 				2E5B76D51971E96AB65B64CF /* Place.swift in Sources */,
+				6F371D3B6BC196A4F7FC48C6 /* ContactPlace.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -758,6 +766,8 @@
 				5E290EEDAE694A24601B9B21 /* TemptationLogger.swift in Sources */,
 				6B8626F4730E92DF4F21C2C8 /* Place.swift in Sources */,
 				A47A6A4C85D3401311EDEEC5 /* PlaceNameSheet.swift in Sources */,
+				2EB7D9796333E9B0D1CEDD6E /* ContactPlace.swift in Sources */,
+				D830477B0140A2278C952D21 /* ContactMatcher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1160,6 +1170,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Resistor;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
+				INFOPLIST_KEY_NSContactsUsageDescription = "Used only if you turn on contact matching, to suggest a contact's name when you name a place. Addresses stay on this device.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Needed to track resistance locations.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1198,6 +1209,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Resistor;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
+				INFOPLIST_KEY_NSContactsUsageDescription = "Used only if you turn on contact matching, to suggest a contact's name when you name a place. Addresses stay on this device.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Needed to track resistance locations.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Resistor/Models/ContactPlace.swift
+++ b/Resistor/Models/ContactPlace.swift
@@ -1,0 +1,72 @@
+import Foundation
+import CoreLocation
+import SwiftData
+
+/// A contact's postal address, forward-geocoded once, so `PlaceNameSheet` can
+/// offer "Mom" at the coordinate where Mom lives instead of the coffee shop
+/// across the street.
+///
+/// **Not a `Place`, deliberately, despite the identical shape.** A `Place` is a
+/// name the user confirmed, and it *applies* — it renames every event within
+/// `Place.matchRadius`, retroactively, in History, on the map, in Insights and in
+/// `PatternFinder`. A `ContactPlace` only *suggests*: it fills a text field the
+/// user still has to save. Collapsing the two would auto-name every event logged
+/// near a friend's flat.
+///
+/// **Device-local, never synced.** `SharedModelContainer` gives this model its
+/// own store with `cloudKitDatabase: .none`, so no address leaves the phone,
+/// there is no `CD_ContactPlace` record type to hand-deploy to Production, and
+/// the CloudKit-only constraints (no `.unique`, defaults on everything) do not
+/// bind here — the style is kept anyway so a move between configurations stays a
+/// one-line change. This is a *cache* of data Contacts already syncs itself:
+/// rebuildable from Settings at any time, and meaningless on a device whose
+/// address book differs.
+@Model
+final class ContactPlace {
+    var id: UUID = UUID()
+    var name: String = ""
+    var latitude: Double = 0
+    var longitude: Double = 0
+    var createdAt: Date = Date()
+
+    init(name: String, latitude: Double, longitude: Double) {
+        self.id = UUID()
+        self.name = name
+        self.latitude = latitude
+        self.longitude = longitude
+        self.createdAt = Date()
+    }
+}
+
+extension Collection where Element == ContactPlace {
+    /// Names of contacts living within `Place.matchRadius` of the event, nearest
+    /// first, deduplicated.
+    ///
+    /// Shares the radius with `Place` on purpose: it is the distance the app
+    /// already treats as "the same spot", so a suggestion is offered exactly
+    /// when saving it would have covered this event.
+    func matches(_ event: TemptationEvent) -> [String] {
+        guard !event.isInTransit,
+              let lat = event.latitude,
+              let lon = event.longitude else { return [] }
+        let eventLocation = CLLocation(latitude: lat, longitude: lon)
+
+        // Broken into steps with explicit types: the equivalent single chain
+        // over a tuple timed the Swift solver out.
+        var withinRadius: [(name: String, distance: CLLocationDistance)] = []
+        for contactPlace in self where !contactPlace.name.isEmpty {
+            let distance = eventLocation.distance(
+                from: CLLocation(latitude: contactPlace.latitude, longitude: contactPlace.longitude)
+            )
+            if distance <= Place.matchRadius {
+                withinRadius.append((contactPlace.name, distance))
+            }
+        }
+
+        var seen = Set<String>()
+        return withinRadius
+            .sorted { $0.distance < $1.distance }
+            .map(\.name)
+            .filter { seen.insert($0).inserted }
+    }
+}

--- a/Resistor/Services/ContactMatcher.swift
+++ b/Resistor/Services/ContactMatcher.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Contacts
+import CoreLocation
+import Observation
+import SwiftData
+
+/// Builds the `ContactPlace` cache: reads the address book once, forward-geocodes
+/// every contact that has a postal address, and stores the coordinates so
+/// `PlaceNameSheet` can suggest a person's name at their own address.
+///
+/// **Opt-in, and it stays opt-in.** Unlike the Maps suggestions and the contact
+/// *picker* — both of which cost nothing — this needs full `CNContactStore`
+/// access, changes the App Store privacy label, and runs a rate-limited network
+/// geocode per contact. It buys exactly one thing over the picker: the name
+/// appears without the user choosing a source. Nothing in the app depends on it,
+/// and declining leaves every other suggestion working.
+///
+/// Rebuilds from scratch rather than reconciling. The whole set is derived, an
+/// address book is small, and a moved contact would otherwise leave a row
+/// pointing at where they used to live — a suggestion that is not merely stale
+/// but wrong.
+@MainActor
+@Observable
+final class ContactMatcher {
+
+    enum Status: Equatable {
+        case idle
+        case working(done: Int, total: Int)
+        case finished(matched: Int)
+        /// Access refused, or previously refused — the prompt only ever appears
+        /// once, so the app must say where to change it.
+        case denied
+        /// Access granted, but no contact has a postal address to geocode.
+        case noAddresses
+        case failed
+    }
+
+    private(set) var status: Status = .idle
+
+    var isWorking: Bool {
+        if case .working = status { return true }
+        return false
+    }
+
+    /// A line of plain status for the Settings row. Nil when there is nothing to
+    /// say — the row's own content already reports the resting state.
+    var statusText: String? {
+        switch status {
+        case .idle: return nil
+        case .working(let done, let total):
+            return total == 0 ? "Reading contacts…" : "Matching \(done) of \(total)…"
+        case .finished(let matched):
+            return matched == 0 ? "No contact addresses could be located." : nil
+        case .denied: return "Contacts access is off. Turn it on in Settings › Privacy › Contacts."
+        case .noAddresses: return "No contacts have a postal address."
+        case .failed: return "Could not read contacts."
+        }
+    }
+
+    /// ponytail: one geocode a second, serially, no retry. `CLGeocoder` throttles
+    /// above roughly that and a throttled request fails the same way a bad
+    /// address does, so pacing is what keeps a large address book from returning
+    /// mostly nothing. A skipped contact costs one suggestion and the user can
+    /// re-run. Batch it if Apple ever ships a bulk API.
+    private static let geocodePacing = Duration.seconds(1)
+
+    func rebuild(in context: ModelContext) async {
+        status = .working(done: 0, total: 0)
+
+        guard await requestAccess() else {
+            status = .denied
+            return
+        }
+
+        let candidates: [(name: String, address: CNPostalAddress)]
+        do {
+            candidates = try Self.addressedContacts()
+        } catch {
+            print("Contact fetch failed: \(error)")
+            status = .failed
+            return
+        }
+
+        guard !candidates.isEmpty else {
+            status = .noAddresses
+            return
+        }
+
+        // Cleared up front, not at the end: a run cancelled halfway then leaves
+        // a partial cache rather than the previous one plus duplicates of
+        // whatever it re-geocoded.
+        clear(in: context)
+
+        let geocoder = CLGeocoder()
+        var matched = 0
+        for (index, candidate) in candidates.enumerated() {
+            if Task.isCancelled { break }
+            status = .working(done: index, total: candidates.count)
+            if index > 0 { try? await Task.sleep(for: Self.geocodePacing) }
+
+            guard let coordinate = try? await geocoder
+                .geocodePostalAddress(candidate.address)
+                .first?
+                .location?
+                .coordinate else { continue }
+
+            context.insert(ContactPlace(
+                name: candidate.name,
+                latitude: coordinate.latitude,
+                longitude: coordinate.longitude
+            ))
+            matched += 1
+        }
+
+        try? context.save()
+        status = .finished(matched: matched)
+    }
+
+    func clear(in context: ModelContext) {
+        try? context.delete(model: ContactPlace.self)
+        try? context.save()
+        if case .working = status {} else { status = .idle }
+    }
+
+    // MARK: - Contacts
+
+    private func requestAccess() async -> Bool {
+        await withCheckedContinuation { continuation in
+            CNContactStore().requestAccess(for: .contacts) { granted, error in
+                if let error { print("Contacts access failed: \(error)") }
+                continuation.resume(returning: granted)
+            }
+        }
+    }
+
+    /// Every contact carrying both a name and a postal address. The first
+    /// address only — a contact with home *and* work addresses would otherwise
+    /// suggest the same name at two coordinates, which reads as a bug at the one
+    /// the user is not standing in.
+    private static func addressedContacts() throws -> [(name: String, address: CNPostalAddress)] {
+        let request = CNContactFetchRequest(keysToFetch: [
+            CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
+            CNContactPostalAddressesKey as CNKeyDescriptor
+        ])
+        var found: [(name: String, address: CNPostalAddress)] = []
+        try CNContactStore().enumerateContacts(with: request) { contact, _ in
+            guard let address = contact.postalAddresses.first?.value else { return }
+            let name = CNContactFormatter.string(from: contact, style: .fullName)
+                ?? contact.organizationName
+            guard !name.isEmpty else { return }
+            found.append((name, address))
+        }
+        return found
+    }
+}

--- a/Resistor/Shared/SharedModelContainer.swift
+++ b/Resistor/Shared/SharedModelContainer.swift
@@ -33,14 +33,44 @@ enum SharedModelContainer {
     /// File name of the SwiftData store inside the App Group container.
     private static let storeFileName = "Resistor.store"
 
-    /// The schema shared by app and widget. Keep in sync with the app's models.
-    static var schema: Schema {
+    /// File name of the device-local store — see `localSchema`.
+    private static let localStoreFileName = "ContactPlaces.store"
+
+    /// The synced models: the user's own data, mirrored to CloudKit.
+    static var cloudSchema: Schema {
         Schema([
             Habit.self,
             TemptationEvent.self,
             UserSettings.self,
             ContextTag.self,
             Place.self
+        ])
+    }
+
+    /// The device-local models, in their own store with `cloudKitDatabase:
+    /// .none`.
+    ///
+    /// `ContactPlace` is a derived cache of the address book — geocoded from
+    /// Contacts, which the user's devices already sync themselves. Keeping it
+    /// out of CloudKit means no postal address ever leaves the phone, and no
+    /// `CD_ContactPlace` record type has to be created by hand and deployed to
+    /// Production before the feature works for a TestFlight user (see CLAUDE.md
+    /// → "The Production schema is a separate thing you must deploy by hand").
+    /// It costs a rebuild per device, which is the Settings button that made it.
+    static var localSchema: Schema {
+        Schema([ContactPlace.self])
+    }
+
+    /// Every model in the container, across both configurations. Keep in sync
+    /// with the app's models.
+    static var schema: Schema {
+        Schema([
+            Habit.self,
+            TemptationEvent.self,
+            UserSettings.self,
+            ContextTag.self,
+            Place.self,
+            ContactPlace.self
         ])
     }
 
@@ -58,24 +88,43 @@ enum SharedModelContainer {
     /// how to handle failure (the app fatal-errors as before; the widget treats
     /// it as the store-unavailable state).
     static func makeContainer() throws -> ModelContainer {
-        let configuration: ModelConfiguration
+        let cloudConfiguration: ModelConfiguration
+        let localConfiguration: ModelConfiguration
         if let url = storeURL {
-            configuration = ModelConfiguration(
-                schema: schema,
+            cloudConfiguration = ModelConfiguration(
+                schema: cloudSchema,
                 url: resolvedStoreURL(groupStore: url),
                 cloudKitDatabase: .automatic
+            )
+            localConfiguration = ModelConfiguration(
+                "ContactPlaces",
+                schema: localSchema,
+                url: url.deletingLastPathComponent().appendingPathComponent(localStoreFileName),
+                cloudKitDatabase: .none
             )
         } else {
             // App Group container unavailable — fall back to the default
             // location so the app still functions (the widget will report
             // store-unavailable when it can't see this store).
-            configuration = ModelConfiguration(
-                schema: schema,
+            cloudConfiguration = ModelConfiguration(
+                schema: cloudSchema,
                 isStoredInMemoryOnly: false,
                 cloudKitDatabase: .automatic
             )
+            localConfiguration = ModelConfiguration(
+                "ContactPlaces",
+                schema: localSchema,
+                isStoredInMemoryOnly: false,
+                cloudKitDatabase: .none
+            )
         }
-        return try ModelContainer(for: schema, configurations: [configuration])
+        // No migration for the local store, deliberately: it has never existed
+        // anywhere else, and it is a cache — an empty one costs a tap on the
+        // Settings button, not data.
+        return try ModelContainer(
+            for: schema,
+            configurations: [cloudConfiguration, localConfiguration]
+        )
     }
 
     // MARK: - Legacy Store Migration

--- a/Resistor/Views/HabitsView.swift
+++ b/Resistor/Views/HabitsView.swift
@@ -13,6 +13,8 @@ struct HabitsView: View {
     @State private var showExportSheet = false
     @State private var exportURL: URL?
     @State private var newTagName: String = ""
+    @Query private var contactPlaces: [ContactPlace]
+    @State private var contactMatcher = ContactMatcher()
     /// Owned rather than read from `\.editMode`, because `EditButton` installs
     /// that inside the `NavigationStack` — below this view's own environment —
     /// so the rows could never tell whether the grip hint should stand down.
@@ -301,6 +303,46 @@ struct HabitsView: View {
                 .buttonStyle(.plain)
                 .disabled(newTagName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
+        }
+
+        contactMatchingSection
+    }
+
+    /// Opt-in address-book matching, so naming a place can suggest the person
+    /// who lives there.
+    ///
+    /// An action and a resting state, not a `Toggle`. A toggle would have to
+    /// flip itself back off when a run finds nothing to match — every contact
+    /// without an address, or access declined — which reads as the switch being
+    /// broken. There is no setting here: either matches exist or they don't.
+    @ViewBuilder
+    private var contactMatchingSection: some View {
+        Section {
+            if contactPlaces.isEmpty {
+                Button("Match My Contacts") {
+                    Task { await contactMatcher.rebuild(in: modelContext) }
+                }
+                .disabled(contactMatcher.isWorking)
+            } else {
+                LabeledContent(
+                    "Matched",
+                    value: contactPlaces.count == 1 ? "1 contact" : "\(contactPlaces.count) contacts"
+                )
+                Button("Remove Contact Matches", role: .destructive) {
+                    contactMatcher.clear(in: modelContext)
+                }
+                .disabled(contactMatcher.isWorking)
+            }
+
+            if let statusText = contactMatcher.statusText {
+                Text(statusText)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            Text("Contacts")
+        } footer: {
+            Text("Looks up your contacts' addresses once, so naming a place can suggest whoever lives there. Addresses stay on this device.")
         }
     }
 

--- a/Resistor/Views/HistoryView.swift
+++ b/Resistor/Views/HistoryView.swift
@@ -58,6 +58,11 @@ struct HistoryView: View {
     }
 
     @State private var selectedEvent: TemptationEvent?
+    /// The event whose spot is being named from a row swipe. Separate state, and
+    /// its sheet hangs off the list rather than off `body` — two `.sheet(item:)`
+    /// on one view is a presentation race, and this one has to be able to open
+    /// while the detail sheet is not up.
+    @State private var namingEvent: TemptationEvent?
 
     var body: some View {
         Group {
@@ -105,6 +110,17 @@ struct HistoryView: View {
             }
         }
         .listStyle(.insetGrouped)
+        .sheet(item: $namingEvent) { event in
+            PlaceNameSheet(event: event)
+        }
+    }
+
+    /// True when the row is showing a coarse geocoded string or a raw lat/lon —
+    /// the moment naming is worth offering, because what the user is reading is
+    /// the fallback. A named spot, a missing coordinate and an in-transit event
+    /// all have nothing to name.
+    private func canName(_ event: TemptationEvent) -> Bool {
+        event.hasLocation && !event.isInTransit && places.match(event) == nil
     }
 
     @ViewBuilder
@@ -189,6 +205,18 @@ struct HistoryView: View {
                 deleteEvent(event)
             } label: {
                 Label("Delete", systemImage: "trash")
+            }
+        }
+        // Leading edge, so the naming action can never be the one a full swipe
+        // fires by accident — that edge belongs to Delete.
+        .swipeActions(edge: .leading) {
+            if canName(event) {
+                Button {
+                    namingEvent = event
+                } label: {
+                    Label("Name", systemImage: "mappin.and.ellipse")
+                }
+                .tint(.accentColor)
             }
         }
     }

--- a/Resistor/Views/PlaceNameSheet.swift
+++ b/Resistor/Views/PlaceNameSheet.swift
@@ -14,6 +14,7 @@ struct PlaceNameSheet: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
     @Query(sort: \Place.createdAt) private var places: [Place]
+    @Query private var contactPlaces: [ContactPlace]
 
     @State private var name: String = ""
     @State private var didLoad = false
@@ -61,10 +62,10 @@ struct PlaceNameSheet: View {
                     Text("Events logged within \(radiusText) of here show this name.")
                 }
 
-                if !nearby.isEmpty {
+                if !nearbySuggestions.isEmpty {
                     Section("Nearby") {
-                        ForEach(nearby, id: \.self) { poi in
-                            Button(poi) { name = poi }
+                        ForEach(nearbySuggestions, id: \.self) { suggestion in
+                            Button(suggestion) { name = suggestion }
                         }
                     }
                 }
@@ -108,6 +109,15 @@ struct PlaceNameSheet: View {
             }
         }
         .presentationDetents([.medium])
+    }
+
+    /// Everything offered for this coordinate: contacts who live here first,
+    /// then businesses. Contacts lead because a matched address is a far
+    /// narrower claim than "one of the POIs within 150 m", so it is more often
+    /// the answer — and there are rarely more than one or two, where the POI
+    /// list is capped at six and would otherwise bury them.
+    private var nearbySuggestions: [String] {
+        Self.nearbyNames(from: contactPlaces.matches(event) + nearby, limit: 8)
     }
 
     /// Businesses at the event's coordinate, offered as one-tap fills. Searched

--- a/ResistorTests/PlaceTests.swift
+++ b/ResistorTests/PlaceTests.swift
@@ -241,4 +241,101 @@ final class PlaceTests: XCTestCase {
         )
         XCTAssertEqual(PlaceNameSheet.nearbyNames(from: raw, limit: 2), ["Blue Bottle", "Safeway"])
     }
+
+    // MARK: - Contact matching
+
+    /// ~110 m north of the base coordinate — inside `matchRadius`.
+    private static let nearLatitude = 37.7759
+    /// ~1.1 km north — outside it.
+    private static let farLatitude = 37.7849
+
+    func testContactMatchesAreWithinRadiusAndNearestFirst() {
+        let habit = TestHelpers.makeHabit()
+        context.insert(habit)
+        let event = TestHelpers.makeEvent(habit: habit, latitude: 37.7749, longitude: -122.4194)
+        context.insert(event)
+
+        let contacts = [
+            ContactPlace(name: "Dana", latitude: Self.nearLatitude, longitude: -122.4194),
+            ContactPlace(name: "Sam", latitude: 37.7749, longitude: -122.4194),
+            ContactPlace(name: "Across Town", latitude: Self.farLatitude, longitude: -122.4194)
+        ]
+
+        // Sam is at the coordinate itself, Dana ~110 m away, the third a km out.
+        XCTAssertEqual(contacts.matches(event), ["Sam", "Dana"])
+    }
+
+    func testContactMatchesDropDuplicateNamesAndSkipTransit() {
+        let habit = TestHelpers.makeHabit()
+        context.insert(habit)
+        let contacts = [
+            ContactPlace(name: "Dana", latitude: 37.7749, longitude: -122.4194),
+            // A second address for the same person — one suggestion, not two.
+            ContactPlace(name: "Dana", latitude: Self.nearLatitude, longitude: -122.4194)
+        ]
+
+        let stationary = TestHelpers.makeEvent(habit: habit, latitude: 37.7749, longitude: -122.4194)
+        context.insert(stationary)
+        XCTAssertEqual(contacts.matches(stationary), ["Dana"])
+
+        // A coordinate the user drove through is not a place, so it gets no
+        // suggestion — the same rule `displayName(for:)` applies.
+        let driving = TestHelpers.makeEvent(
+            habit: habit,
+            latitude: 37.7749,
+            longitude: -122.4194,
+            speedMps: 20
+        )
+        context.insert(driving)
+        XCTAssertEqual(contacts.matches(driving), [])
+    }
+
+    /// The production container splits its models across two configurations —
+    /// the user's data to CloudKit, the contact cache to a device-local store.
+    /// A build cannot catch a bad split; `ModelContainer` throws at launch, and
+    /// the app fatal-errors on that.
+    func testCloudAndLocalConfigurationsOpenAsOneContainer() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let container = try ModelContainer(
+            for: SharedModelContainer.schema,
+            configurations: [
+                ModelConfiguration(
+                    schema: SharedModelContainer.cloudSchema,
+                    url: directory.appendingPathComponent("Resistor.store"),
+                    cloudKitDatabase: .none
+                ),
+                ModelConfiguration(
+                    "ContactPlaces",
+                    schema: SharedModelContainer.localSchema,
+                    url: directory.appendingPathComponent("ContactPlaces.store"),
+                    cloudKitDatabase: .none
+                )
+            ]
+        )
+
+        // Both stores are writable and readable through the one context.
+        let context = ModelContext(container)
+        context.insert(Place(name: "Home", latitude: 37.7749, longitude: -122.4194))
+        context.insert(ContactPlace(name: "Dana", latitude: 37.7749, longitude: -122.4194))
+        try context.save()
+
+        XCTAssertEqual(try context.fetch(FetchDescriptor<Place>()).map(\.name), ["Home"])
+        XCTAssertEqual(try context.fetch(FetchDescriptor<ContactPlace>()).map(\.name), ["Dana"])
+    }
+
+    /// The point of the split: the contact cache must not be in the schema that
+    /// mirrors to CloudKit, or every address book entry syncs to iCloud and
+    /// `CD_ContactPlace` becomes a record type someone has to deploy by hand.
+    func testContactCacheIsNotInTheCloudSchema() {
+        let cloudNames = SharedModelContainer.cloudSchema.entities.map(\.name)
+        XCTAssertFalse(cloudNames.contains("ContactPlace"), "ContactPlace must stay out of CloudKit")
+        XCTAssertEqual(SharedModelContainer.localSchema.entities.map(\.name), ["ContactPlace"])
+        // The container schema still has to cover both, or it cannot open.
+        let allNames = Set(SharedModelContainer.schema.entities.map(\.name))
+        XCTAssertTrue(allNames.isSuperset(of: Set(cloudNames + ["ContactPlace"])))
+    }
 }

--- a/ResistorTests/TestHelpers.swift
+++ b/ResistorTests/TestHelpers.swift
@@ -6,7 +6,7 @@ import Foundation
 enum TestHelpers {
     @MainActor
     static func makeModelContainer() throws -> ModelContainer {
-        let schema = Schema([Habit.self, TemptationEvent.self, UserSettings.self, Place.self, ContextTag.self])
+        let schema = Schema([Habit.self, TemptationEvent.self, UserSettings.self, Place.self, ContextTag.self, ContactPlace.self])
         let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
         return try ModelContainer(for: schema, configurations: [config])
     }

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,25 +1,40 @@
 Naming a place no longer has to be typing.
 
-Open the Name This Place sheet — tap a pin on the Event Map, or the Location row
-in a History event's detail — and it now offers the names of businesses at that
-coordinate as one-tap fills, under "Nearby". There is also a "From Contacts"
-button, for the places that are a person's rather than a business: it opens the
-system contact picker and fills the field with the name you tap.
+Open the Name This Place sheet and it now offers names as one-tap fills, under
+"Nearby": the businesses at that coordinate, and — if you turn on contact
+matching — anyone in your address book who lives there. There is also a "From
+Contacts" button that opens the system contact picker, for the places that are a
+person's rather than a business.
+
+There is a third way into the sheet now, alongside tapping a pin on the Event Map
+and the Location row in an event's detail: swipe a History row from the left. It
+appears only on rows still showing a neighbourhood or a raw coordinate, which is
+the moment naming is worth offering.
 
 Nothing is applied for you. A hundred-metre fix in a strip mall has a dozen
 plausible answers, and a confidently wrong one is worse than none, because a
 place name feeds Insights and the Patterns card. The suggestions fill the text
 field; you still confirm with Save, and you can still type anything.
 
-The contact picker asks for no permission and reads no addresses. It runs
-outside the app and hands back only the name of the contact you tapped — the
-place is still saved at the event's own coordinate.
+Contact matching is off until you press Habits › Contacts › "Match My Contacts".
+That one asks for address-book access and takes about a second per contact, so
+give it a moment on a large address book. The addresses are stored on the phone
+only — unlike everything else in the app they are never synced to iCloud, so
+you would run it once per device. "Remove Contact Matches" deletes them.
+
+The "From Contacts" button needs none of that: the picker runs outside the app,
+asks for no permission, and hands back only the name of the contact you tap.
+Neither path stores an address on the event — the place still saves at the
+coordinate you logged at.
 
 Worth checking: open the sheet somewhere with businesses around and confirm the
 Nearby list is plausible; confirm "From Contacts" opens the picker without a
-permission prompt and fills the field; confirm an event logged in transit still
-offers no naming at all.
+permission prompt; run contact matching and confirm a friend's name shows up when
+you log at their place; confirm the History swipe offers "Name" on an unnamed row
+and not on one already named; confirm an event logged in transit still offers no
+naming at all.
 
-The useful thing to report: a Nearby list that is empty or obviously wrong where
-you would expect a business, and whether the contact picker ever prompts for
-address-book access.
+The useful thing to report: how long contact matching takes and how many of your
+contacts it found, a Nearby list that is empty or obviously wrong where you would
+expect a business, and whether the contact picker ever prompts for address-book
+access.

--- a/scripts/add_contact_matching_files.rb
+++ b/scripts/add_contact_matching_files.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+# Adds the contact place-suggestion sources to the Xcode project (issue #78,
+# Stage B). Idempotent — rerun if the file references are lost.
+#
+#   export GEM_HOME="$HOME/.gem/ruby/2.6.0"; export PATH="$GEM_HOME/bin:$PATH"
+#   ruby scripts/add_contact_matching_files.rb
+#
+# ContactPlace.swift goes in the widget target too: it is part of
+# SharedModelContainer's schema, which the widget compiles.
+
+require 'xcodeproj'
+
+project_path = File.expand_path('../Resistor.xcodeproj', __dir__)
+project = Xcodeproj::Project.open(project_path)
+
+app = project.targets.find { |t| t.name == 'Resistor' }
+widget = project.targets.find { |t| t.name == 'ResistorWidget' }
+raise 'Resistor target not found' unless app
+
+# path relative to the project root => targets that compile it
+FILES = {
+  'Resistor/Models/ContactPlace.swift' => [app, widget].compact,
+  'Resistor/Services/ContactMatcher.swift' => [app]
+}.freeze
+
+FILES.each do |path, targets|
+  basename = File.basename(path)
+  group_path = File.dirname(path)
+
+  group = project.main_group
+  group_path.split('/').each do |component|
+    group = group.find_subpath(component, true)
+  end
+  group.set_source_tree('<group>')
+
+  file_ref = group.files.find { |f| f.path == basename } ||
+             group.new_reference(basename)
+
+  targets.each do |target|
+    already = target.source_build_phase.files.any? { |bf| bf.file_ref == file_ref }
+    next if already
+
+    target.add_file_references([file_ref])
+    puts "Added #{basename} to #{target.name}"
+  end
+end
+
+# NSContactsUsageDescription: Contacts pre-matching (Stage B) calls
+# CNContactStore.requestAccess. The contact *picker* needs no key — it runs out
+# of process — so this covers only the opt-in Settings action.
+app.build_configurations.each do |config|
+  config.build_settings['INFOPLIST_KEY_NSContactsUsageDescription'] =
+    'Used only if you turn on contact matching, to suggest a contact\'s name when you name a place. Addresses stay on this device.'
+end
+
+project.save
+puts 'Saved project.'


### PR DESCRIPTION
The two things #78 listed that PR #80 skipped. Closes #78.

### Stage B — opt-in contact matching
Habits › Contacts › **"Match My Contacts"** reads the address book once, forward-geocodes every contact with a postal address, and caches the coordinates so `PlaceNameSheet` suggests the person who lives there — without the user picking a source. That is the *only* thing it buys over the picker already shipped, and it costs full Contacts access, a privacy label and a rate-limited geocode per contact. So: a button, never automatic, and declining leaves every other suggestion working.

`ContactPlace` is deliberately not a `Place` despite the identical shape. A `Place` **applies** — it renames every event within 150 m, retroactively, into Insights and `PatternFinder`. A `ContactPlace` only fills a field the user still has to Save.

### It lives in its own store
`SharedModelContainer` now opens **one container over two configurations**: the user's data to CloudKit as before, `ContactPlace` with `cloudKitDatabase: .none`.

- No postal address leaves the phone — it's geocoded from Contacts, which already syncs itself.
- No `CD_ContactPlace` record type to create by hand and deploy to Production before TestFlight users see anything.
- Cost is a rebuild per device, which is the button that made it. The cache is derived and disposable.

### Settings shows an action, not a Toggle
A toggle would have to flip itself back off whenever a run matched nothing (access declined, or no contact has an address), which reads as a broken switch. Nothing here is a setting — either matches exist or they don't.

### Third way into the sheet
A **leading-edge** swipe on a History row, offered only when `canName` holds (located, not in transit, no `Place` matching yet) — i.e. exactly when the row is showing the geocoded fallback or a raw lat/lon that naming would replace. Trailing stays Delete's, because that's the edge a full swipe fires.

### Verification
- 325 unit tests pass; watch target builds.
- **App launched on the simulator.** The two-configuration container throws at *launch*, not compile — a green build proves nothing about it, and `ResistorApp` fatal-errors on the throw.
- `testCloudAndLocalConfigurationsOpenAsOneContainer` covers the split; `testContactCacheIsNotInTheCloudSchema` pins the cache out of CloudKit, where a leak back in would be silent and permanent.
- Settings section screenshotted via the UI harness (`04-Habits-c`).

Not verified on device: the actual geocode against a real address book (rate, hit rate, wall-clock), and that `NSContactsUsageDescription` prompts as written. Both are in the TestFlight notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sdMoCETcfDumJBdarLpba