### PR TITLE
Search the full icon catalogue, and widen the habit palette to 20

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Resistor/
     ├── HistoryView.swift             # Past events list + detail sheet
     ├── EventMapView.swift            # Map view for location-tagged events
     ├── PlaceNameSheet.swift          # Name/rename the spot an event was logged
+    ├── HabitStylePicker.swift        # Colour + icon sections shared by both habit forms
     └── OnboardingView.swift          # First-run flow (S0)
 ```
 
@@ -335,12 +336,16 @@ history icon, Log card and widget — the raw iOS system wheel (`#007AFF`,
 the parts a user actually looked at were the parts that looked like a default.
 Three rules keep it unified:
 
-- `HabitsViewModel.availableColors` is the **habit** palette (Sand, Clay, Rose,
-  Periwinkle, Slate Blue, Teal, Sage, Moss, Ochre, Storm); it and
-  `UserSettings.accentPalette` are the only palettes. Everything is mid-tone
-  because a habit colour has to work as chart ink and as a filled glyph on both
-  a white card and a black one. New habits take `availableColors[0]` — don't
-  reintroduce a `#007AFF` literal at a creation site.
+- `HabitsViewModel.availableColors` is the **habit** palette — 20 hues ordered
+  warm → cool → neutral so the grid reads as a sweep rather than as an
+  accretion; it and `UserSettings.accentPalette` are the only palettes.
+  Everything is mid-tone because a habit colour has to work as chart ink and as
+  a filled glyph on both a white card and a black one. New habits take
+  `availableColors[0]` (Sand stays first for that reason) — don't reintroduce a
+  `#007AFF` literal at a creation site. `testColorsAreMidTone` pins the
+  lightness band, which is the part that actually stops rendering;
+  "muted" itself is a design judgement no threshold separates cleanly from the
+  system wheel, so it isn't asserted.
 - `TemptationEvent.Outcome.color` is **not** `.green` / `.orange` / `.gray`.
   Those three are the most-repeated ink in the app (History badges, the Outcomes
   bar, the Log confirmation banner, map pins) and at full saturation they were
@@ -357,6 +362,49 @@ Three rules keep it unified:
   falling through to `.accentColor` made the one screen every user sees the one
   screen with none of the app's own colour in it. `UserSettings` owns the accent
   palette because three separate views resolve it.
+
+### Habit icons: a curated catalogue behind a search box
+
+There is **no public API to enumerate SF Symbols**, so the reachable set is a
+hand-written list in `HabitsViewModel`, in three parts:
+
+- `availableIcons` — the ~20 common habits, shown when the search box is empty,
+  and the source of the `circle.fill` default.
+- `iconCatalog` — everything else the search can reach, grouped by what someone
+  might be tracking. Curated, not exhaustive: a flat grid of several thousand
+  symbols is unusable, and the empty state is the suggested set precisely so the
+  common case doesn't change.
+- `iconKeywords` — search words a symbol's own **name** doesn't contain. Matching
+  reads dots as spaces, so "run" already finds `figure.run`; this covers the
+  cases where it doesn't, and nothing in `cup.and.saucer.fill` says coffee.
+  `testEveryKeywordedIconIsInTheCatalog` catches a key that names no symbol,
+  which would otherwise be silent dead weight.
+
+**A wrong name doesn't fail — it renders nothing.** `Image(systemName:)` on a
+name that isn't a symbol draws a blank and reports no error, so `allIcons` filters
+the catalogue through `UIImage(systemName:)` at runtime, and
+`testEveryCatalogIconIsARealSymbol` asserts every entry resolves. Those two look
+redundant and aren't: the filter is for a symbol a *later* SDK added, which
+should degrade to absent on an older OS; the test is for a typo, which should
+fail the build. Without the test, a typo is indistinguishable from the first case.
+
+That is not hypothetical. `"cigarette.fill"` shipped in `availableIcons` from v1
+and drew a blank tile the whole time — Apple ships no cigarette symbol under any
+name (issue #82). Smoking being near the app's central use case, it was close to
+the worst possible entry to have broken. `smoke.fill` replaced it, and
+`"cigarette"` is a keyword on `smoke.fill` and `lungs.fill` so the word still
+reaches a glyph. **Verify a new symbol name against a real `UIImage(systemName:)`
+call rather than against how plausible it looks** — plausibility is exactly what
+made this survive.
+
+`HabitStylePicker` is the Color and Icon `Section`s of a habit form, shared by
+the Habits screen's editor and the Log screen's Add Habit sheet, which carried
+identical copies. One copy, so the search only had to be built once. It also
+prepends the selected icon to the default grid when the icon isn't one of the
+suggested twenty — otherwise editing a habit whose icon came from a search opens
+on a grid with nothing selected in it. **Onboarding deliberately keeps its own
+horizontal strips** and offers no search: it is a first-run flow, its layout is a
+scroll strip rather than a form, and the icon is changeable a tap later.
 
 ### Manual Cascade Deletion
 
@@ -1039,13 +1087,13 @@ coexist on disk; each mode only cleans its own files.
 
 ## Open GitHub Issues
 
-Current as of 2026-08-03. Everything previously listed here (#35 icon, #37
-accessibility, #47 widget, #48 haptics, #49 watch) is closed.
+Current as of 2026-08-04. Everything previously listed here (#35 icon, #37
+accessibility, #47 widget, #48 haptics, #49 watch, #61/#62 Log layout, #63 icon
+and colour choices, #78 place-name suggestions, #82 blank cigarette glyph) is
+closed.
 
 - #53 — Log screen: surface multiple habits (scrollable list) to use the empty space
-- #61 — Log screen: habit card content is top-justified, not centered
-- #62 — Log screen: habit pager sits above the card, should be below
-- #63 — Habit editor: expand icon and color choices (icon search)
+- #77 — Calendar as a pattern facet: tag an event with the meeting it overlapped
 
 **Two of those closed without the device check they asked for**, which is worth
 knowing before trusting them:

--- a/Resistor.xcodeproj/project.pbxproj
+++ b/Resistor.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		8C41ECC1C5222C46E02AACD8 /* TemptationLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E671048A9259B7EBC8C1B43 /* TemptationLogger.swift */; };
 		9019D281C1C4357A3751544B /* ResistorWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 821F40704A2FEA56AED6D538 /* ResistorWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		9323F6EB4158AC92D2B96065 /* ShakeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BF00C891AC6A8DE660DA6C /* ShakeDetector.swift */; };
+		9AAF0859F4071502636E741B /* HabitStylePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A1B2572B8A1F52A7269A39 /* HabitStylePicker.swift */; };
 		9D3EDFD17E3756C5D1FCB5E7 /* WatchModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE4E3C730BCF819722BC72C /* WatchModelContainer.swift */; };
 		A1000001000000000000001A /* ResistorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000001000000000000000A /* ResistorApp.swift */; };
 		A1000002000000000000001A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000002000000000000000A /* ContentView.swift */; };
@@ -196,6 +197,7 @@
 		92336A99675FFE2911DBEE63 /* ShakeDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShakeDetectorTests.swift; sourceTree = "<group>"; };
 		95D889C949679DFDA0EC69EA /* ResistorWatchComplication.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ResistorWatchComplication.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A7A220FBBC346EEC2773BB4 /* SnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnapshotTests.swift; sourceTree = "<group>"; };
+		A0A1B2572B8A1F52A7269A39 /* HabitStylePicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HabitStylePicker.swift; sourceTree = "<group>"; };
 		A1000000000000000000000A /* Resistor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Resistor.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1000001000000000000000A /* ResistorApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResistorApp.swift; sourceTree = "<group>"; };
 		A1000002000000000000000A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -447,6 +449,7 @@
 				A1000011000000000000000A /* HistoryView.swift */,
 				43CA41D22F89730100D11E7D /* EventMapView.swift */,
 				EAF424CFFC2794EAA9148F6D /* PlaceNameSheet.swift */,
+				A0A1B2572B8A1F52A7269A39 /* HabitStylePicker.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -768,6 +771,7 @@
 				A47A6A4C85D3401311EDEEC5 /* PlaceNameSheet.swift in Sources */,
 				2EB7D9796333E9B0D1CEDD6E /* ContactPlace.swift in Sources */,
 				D830477B0140A2278C952D21 /* ContactMatcher.swift in Sources */,
+				9AAF0859F4071502636E741B /* HabitStylePicker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resistor/ViewModels/HabitsViewModel.swift
+++ b/Resistor/ViewModels/HabitsViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftData
 import Observation
+import UIKit
 
 @Observable
 final class HabitsViewModel {
@@ -205,19 +206,34 @@ extension HabitsViewModel {
     /// Mid-tone on purpose: a habit colour has to work as chart ink and as a
     /// filled glyph on both a white card and a black one, so nothing here goes
     /// near the light or dark end.
+    /// Ordered warm → cool → neutral rather than by when a hue was added, so the
+    /// grid reads as a sweep. Sand stays first because index 0 is what a new
+    /// habit takes.
     static let availableColors: [(name: String, hex: String)] = [
         ("Sand", "#E8A87C"),
         ("Clay", "#C97B63"),
-        ("Rose", "#C77D8A"),
-        ("Periwinkle", "#7D7AA8"),
-        ("Slate Blue", "#6E7FA8"),
-        ("Teal", "#5E9E9E"),
-        ("Sage", "#7F9E76"),
-        ("Moss", "#8A9B5F"),
+        ("Brick", "#B4645C"),
+        ("Bronze", "#A5734F"),
         ("Ochre", "#C6A15B"),
-        ("Storm", "#7A8290")
+        ("Moss", "#8A9B5F"),
+        ("Sage", "#7F9E76"),
+        ("Fern", "#659A65"),
+        ("Mint", "#6FAE94"),
+        ("Teal", "#5E9E9E"),
+        ("Sky", "#6FA3C4"),
+        ("Slate Blue", "#6E7FA8"),
+        ("Indigo", "#6668A0"),
+        ("Periwinkle", "#7D7AA8"),
+        ("Violet", "#9070AD"),
+        ("Lilac", "#B08FC4"),
+        ("Mulberry", "#9C6480"),
+        ("Rose", "#C77D8A"),
+        ("Storm", "#7A8290"),
+        ("Pewter", "#9AA0A8")
     ]
 
+    /// The set shown when the icon search is empty — the common habits, in the
+    /// order they were curated. Also the source of the default (`circle.fill`).
     static let availableIcons: [String] = [
         "circle.fill",
         "star.fill",
@@ -237,7 +253,180 @@ extension HabitsViewModel {
         "cup.and.saucer.fill",
         "fork.knife",
         "wineglass.fill",
-        "cigarette.fill",
+        // Not `cigarette.fill` — Apple ships no cigarette symbol under any
+        // name, so that entry drew a blank tile from v1 until the availability
+        // test caught it. `smoke.fill` carries the smoking keywords instead.
+        "smoke.fill",
         "pills.fill"
     ]
+
+    /// Everything else the search can reach. There is no public API to
+    /// enumerate SF Symbols, so this is a hand-curated catalogue rather than the
+    /// full several-thousand set — which would be unusable in a grid anyway.
+    ///
+    /// Grouped by what someone might be tracking. `allIcons` drops anything the
+    /// running OS doesn't have, so a symbol added in a later SDK degrades to
+    /// absent rather than to a blank square.
+    static let iconCatalog: [String] = [
+        // Shapes and marks
+        "square.fill", "triangle.fill", "diamond.fill", "hexagon.fill",
+        "seal.fill", "shield.fill", "checkmark.circle.fill", "xmark.circle.fill",
+        "exclamationmark.triangle.fill", "questionmark.circle.fill",
+        "flag.fill", "flag.checkered", "bookmark.fill", "tag.fill", "pin.fill",
+        "sparkles", "sparkle", "infinity", "circle.dashed", "target", "scope",
+        "crown.fill", "trophy.fill", "rosette", "burst.fill",
+
+        // Substances
+        "mug.fill", "waterbottle.fill", "takeoutbag.and.cup.and.straw.fill",
+        "cross.vial.fill", "syringe.fill", "bandage.fill", "lungs.fill",
+        "heart.text.square.fill", "cross.case.fill",
+
+        // Food
+        "birthday.cake.fill", "carrot.fill", "fish.fill", "popcorn.fill",
+        "frying.pan.fill", "refrigerator.fill", "waterbottle",
+
+        // Screens and devices
+        "iphone", "ipad", "laptopcomputer", "desktopcomputer", "display",
+        "headphones", "airpods", "message.fill", "bubble.left.fill",
+        "bubble.left.and.bubble.right.fill", "envelope.fill", "video.fill",
+        "camera.fill", "photo.fill", "play.rectangle.fill", "music.note",
+        "speaker.wave.2.fill", "wifi", "antenna.radiowaves.left.and.right",
+        "globe", "network", "bell.fill", "bell.slash.fill", "keyboard",
+
+        // Money and shopping
+        "bag.fill", "dollarsign.circle.fill", "banknote.fill", "giftcard.fill",
+        "gift.fill", "percent", "chart.line.uptrend.xyaxis", "wallet.pass.fill",
+        "storefront.fill", "chart.bar.fill", "chart.pie.fill",
+
+        // Gambling
+        "dice.fill", "suit.spade.fill", "suit.club.fill", "suit.heart.fill",
+        "suit.diamond.fill",
+
+        // Body and exercise
+        "figure.walk", "figure.run", "figure.stand", "figure.yoga",
+        "figure.mind.and.body", "figure.strengthtraining.traditional",
+        "figure.pool.swim", "figure.outdoor.cycle", "figure.2",
+        "dumbbell.fill", "bicycle", "sportscourt.fill", "tennis.racket",
+        "soccerball", "basketball.fill", "football.fill",
+        "brain.head.profile", "brain", "eye.fill", "eye.slash.fill",
+        "mouth.fill", "ear", "hare.fill", "tortoise.fill",
+        "hand.raised.fill", "hand.thumbsup.fill", "hand.thumbsdown.fill",
+        "hand.wave.fill",
+
+        // Time and sleep
+        "bed.double.fill", "moon.zzz.fill", "zzz", "sunrise.fill",
+        "sunset.fill", "alarm.fill", "clock.fill", "timer", "hourglass",
+        "calendar", "stopwatch.fill",
+
+        // Places and travel
+        "house.fill", "building.2.fill", "building.columns.fill", "car.fill",
+        "bus.fill", "tram.fill", "airplane", "fuelpump.fill",
+        "mappin.and.ellipse", "location.fill",
+
+        // Work and study
+        "briefcase.fill", "book.fill", "books.vertical.fill",
+        "graduationcap.fill", "pencil", "highlighter", "doc.fill",
+        "folder.fill", "paperclip", "checklist", "list.bullet", "printer.fill",
+
+        // People
+        "person.fill", "person.2.fill", "person.3.fill", "heart.slash.fill",
+
+        // Outdoors and weather
+        "cloud.rain.fill", "cloud.bolt.fill", "snowflake", "wind", "tree.fill",
+        "mountain.2.fill", "water.waves", "pawprint.fill", "ant.fill",
+        "bird.fill", "dog.fill", "cat.fill",
+
+        // Tools and pastimes
+        "wrench.and.screwdriver.fill", "hammer.fill", "scissors",
+        "paintbrush.fill", "paintpalette.fill", "theatermasks.fill",
+        "ticket.fill", "gearshape.fill", "trash.fill", "waveform",
+        "lock.fill", "key.fill", "arrow.clockwise", "arrow.counterclockwise"
+    ]
+
+    /// Search words a symbol's own name doesn't contain. Only the non-obvious
+    /// ones are listed — "dice" already finds `dice.fill`, but nothing in
+    /// `cup.and.saucer.fill` says coffee.
+    static let iconKeywords: [String: String] = [
+        "cup.and.saucer.fill": "coffee tea caffeine drink",
+        "mug.fill": "coffee tea beer drink",
+        "wineglass.fill": "alcohol wine drink booze beer",
+        "smoke.fill": "smoking cigarette nicotine tobacco vape",
+        "lungs.fill": "smoking cigarette breathing vape",
+        "pills.fill": "drugs medication meds",
+        "cross.vial.fill": "drugs medical",
+        "syringe.fill": "drugs injection",
+        "leaf.fill": "cannabis weed plant nature",
+        "waterbottle.fill": "water hydration drink",
+        "cart.fill": "shopping shop spending",
+        "bag.fill": "shopping shop spending",
+        "creditcard.fill": "spending money debt",
+        "dollarsign.circle.fill": "money spending cash",
+        "banknote.fill": "money cash spending",
+        "storefront.fill": "shopping shop",
+        "dice.fill": "gambling betting casino",
+        "suit.spade.fill": "cards gambling poker",
+        "suit.club.fill": "cards gambling poker",
+        "suit.heart.fill": "cards gambling poker",
+        "suit.diamond.fill": "cards gambling poker",
+        "gamecontroller.fill": "gaming videogames console",
+        "tv.fill": "television streaming binge",
+        "display": "computer screen monitor",
+        "iphone": "phone screen scrolling",
+        "globe": "internet web browsing",
+        "network": "internet web",
+        "message.fill": "texting chat social",
+        "bubble.left.fill": "chat social messaging",
+        "photo.fill": "social feed scrolling",
+        "eye.fill": "watching porn looking",
+        "eye.slash.fill": "avoiding hiding porn",
+        "fork.knife": "food eating meals",
+        "birthday.cake.fill": "sugar sweets dessert cake",
+        "takeoutbag.and.cup.and.straw.fill": "fast food takeaway junk",
+        "popcorn.fill": "snacking cinema movies",
+        "mouth.fill": "biting chewing nails",
+        "bed.double.fill": "sleep bedroom insomnia",
+        "zzz": "sleep tired",
+        "moon.zzz.fill": "sleep night insomnia",
+        "figure.run": "running exercise workout jogging",
+        "figure.walk": "walking exercise steps",
+        "dumbbell.fill": "gym exercise workout weights",
+        "figure.mind.and.body": "meditation mindfulness calm",
+        "brain.head.profile": "mind thinking anxiety rumination",
+        "brain": "mind thinking anxiety",
+        "car.fill": "driving commute",
+        "house.fill": "home",
+        "briefcase.fill": "work job office",
+        "book.fill": "reading study",
+        "graduationcap.fill": "study school learning",
+        "clock.fill": "time procrastination",
+        "hourglass": "time waiting procrastination",
+        "person.2.fill": "friends social people",
+        "heart.slash.fill": "breakup relationship",
+        "hand.raised.fill": "stop resist",
+        "flame.fill": "burn urge craving",
+        "bolt.fill": "energy urge impulse",
+        "music.note": "music listening",
+        "headphones": "music audio podcast",
+        "paintbrush.fill": "art creative hobby",
+        "scissors": "cutting hair",
+        "lock.fill": "blocking restricting",
+        "trash.fill": "waste"
+    ]
+
+    /// Suggested set plus catalogue, minus anything this OS can't draw.
+    static let allIcons: [String] = (availableIcons + iconCatalog)
+        .filter { UIImage(systemName: $0) != nil }
+
+    /// Icons for a search box: the suggested set when the query is empty, and
+    /// otherwise every catalogue symbol matching all of the query's words —
+    /// against the symbol name (dots read as spaces) and its keywords.
+    static func icons(matching query: String) -> [String] {
+        let words = query.lowercased().split(separator: " ").map(String.init)
+        guard !words.isEmpty else { return availableIcons }
+        return allIcons.filter { icon in
+            let haystack = icon.replacingOccurrences(of: ".", with: " ")
+                + " " + (iconKeywords[icon] ?? "")
+            return words.allSatisfy { haystack.contains($0) }
+        }
+    }
 }

--- a/Resistor/Views/HabitStylePicker.swift
+++ b/Resistor/Views/HabitStylePicker.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+/// The Color and Icon sections of a habit form.
+///
+/// Two forms create or edit a habit — the Habits screen's editor and the Log
+/// screen's Add Habit sheet — and they carried identical copies of these grids.
+/// One copy, so the icon search only had to be built once and the two can't
+/// drift apart.
+///
+/// Emits two `Section`s, so it goes straight into a `Form`.
+struct HabitStylePicker: View {
+    @Binding var colorHex: String
+    @Binding var iconName: String
+
+    @State private var iconQuery = ""
+
+    private var color: Color { Color(hex: colorHex) ?? .blue }
+
+    /// The selected icon leads the default grid when it isn't one of the
+    /// suggested twenty — otherwise editing a habit whose icon came from a
+    /// search would open on a grid with nothing selected in it.
+    private var icons: [String] {
+        let matches = HabitsViewModel.icons(matching: iconQuery)
+        guard iconQuery.isEmpty, !iconName.isEmpty, !matches.contains(iconName) else {
+            return matches
+        }
+        return [iconName] + matches
+    }
+
+    var body: some View {
+        Section("Color") {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 44))], spacing: 12) {
+                ForEach(HabitsViewModel.availableColors, id: \.hex) { swatch in
+                    let isSelected = colorHex == swatch.hex
+                    Circle()
+                        .fill(Color(hex: swatch.hex) ?? .blue)
+                        .frame(width: 44, height: 44)
+                        .overlay(
+                            Circle()
+                                .stroke(Color.primary, lineWidth: isSelected ? 3 : 0)
+                        )
+                        .onTapGesture { colorHex = swatch.hex }
+                        .accessibilityLabel(swatch.name)
+                        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+                }
+            }
+            .padding(.vertical, 8)
+        }
+
+        Section("Icon") {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+                TextField("Search symbols", text: $iconQuery)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                if !iconQuery.isEmpty {
+                    Button {
+                        iconQuery = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    // Plain, or the whole row becomes the button's tap target.
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear search")
+                }
+            }
+
+            if icons.isEmpty {
+                Text("No symbols match \"\(iconQuery)\".")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 8)
+            } else {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 50))], spacing: 12) {
+                    ForEach(icons, id: \.self) { icon in
+                        let isSelected = iconName == icon
+                        Image(systemName: icon)
+                            .font(.title2)
+                            .foregroundStyle(isSelected ? color : Color.primary)
+                            .frame(width: 50, height: 50)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(isSelected ? color.opacity(0.2) : Color.clear)
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(isSelected ? color : Color.clear, lineWidth: 2)
+                            )
+                            .onTapGesture { iconName = icon }
+                            .accessibilityLabel(Self.iconLabel(icon))
+                            .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+        }
+    }
+
+    /// "cup.and.saucer.fill" reads as "cup and saucer" to VoiceOver.
+    static func iconLabel(_ icon: String) -> String {
+        icon
+            .replacingOccurrences(of: ".fill", with: "")
+            .replacingOccurrences(of: ".", with: " ")
+    }
+}

--- a/Resistor/Views/HabitsView.swift
+++ b/Resistor/Views/HabitsView.swift
@@ -485,52 +485,16 @@ struct HabitsView: View {
                     .lineLimit(2...4)
                 }
 
-                Section("Color") {
-                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 44))], spacing: 12) {
-                        ForEach(HabitsViewModel.availableColors, id: \.hex) { color in
-                            Circle()
-                                .fill(Color(hex: color.hex) ?? .blue)
-                                .frame(width: 44, height: 44)
-                                .overlay(
-                                    Circle()
-                                        .stroke(Color.primary, lineWidth: vm.selectedColorHex == color.hex ? 3 : 0)
-                                )
-                                .onTapGesture {
-                                    vm.selectedColorHex = color.hex
-                                }
-                                .accessibilityLabel(color.name)
-                                .accessibilityAddTraits(vm.selectedColorHex == color.hex ? [.isButton, .isSelected] : .isButton)
-                        }
-                    }
-                    .padding(.vertical, 8)
-                }
-
-                Section("Icon") {
-                    let selectedColor = Color(hex: vm.selectedColorHex) ?? .blue
-                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 50))], spacing: 12) {
-                        ForEach(HabitsViewModel.availableIcons, id: \.self) { icon in
-                            let isSelected = vm.selectedIconName == icon
-                            Image(systemName: icon)
-                                .font(.title2)
-                                .foregroundStyle(isSelected ? selectedColor : Color.primary)
-                                .frame(width: 50, height: 50)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .fill(isSelected ? selectedColor.opacity(0.2) : Color.clear)
-                                )
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .stroke(isSelected ? selectedColor : Color.clear, lineWidth: 2)
-                                )
-                                .onTapGesture {
-                                    vm.selectedIconName = icon
-                                }
-                                .accessibilityLabel(icon.replacingOccurrences(of: ".fill", with: "").replacingOccurrences(of: ".", with: " "))
-                                .accessibilityAddTraits(vm.selectedIconName == icon ? [.isButton, .isSelected] : .isButton)
-                        }
-                    }
-                    .padding(.vertical, 8)
-                }
+                HabitStylePicker(
+                    colorHex: Binding(
+                        get: { vm.selectedColorHex },
+                        set: { vm.selectedColorHex = $0 }
+                    ),
+                    iconName: Binding(
+                        get: { vm.selectedIconName },
+                        set: { vm.selectedIconName = $0 }
+                    )
+                )
 
                 // Preview
                 Section("Preview") {

--- a/Resistor/Views/LogView.swift
+++ b/Resistor/Views/LogView.swift
@@ -789,48 +789,7 @@ private struct AddHabitFromLogSheet: View {
                     .lineLimit(2...4)
                 }
 
-                Section("Color") {
-                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 44))], spacing: 12) {
-                        ForEach(HabitsViewModel.availableColors, id: \.hex) { color in
-                            Circle()
-                                .fill(Color(hex: color.hex) ?? .blue)
-                                .frame(width: 44, height: 44)
-                                .overlay(
-                                    Circle()
-                                        .stroke(Color.primary, lineWidth: selectedColor == color.hex ? 3 : 0)
-                                )
-                                .onTapGesture { selectedColor = color.hex }
-                                .accessibilityLabel(color.name)
-                                .accessibilityAddTraits(selectedColor == color.hex ? .isSelected : [])
-                        }
-                    }
-                    .padding(.vertical, 8)
-                }
-
-                Section("Icon") {
-                    let iconColor = Color(hex: selectedColor) ?? .blue
-                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 50))], spacing: 12) {
-                        ForEach(HabitsViewModel.availableIcons, id: \.self) { icon in
-                            let isSelected = selectedIcon == icon
-                            Image(systemName: icon)
-                                .font(.title2)
-                                .foregroundStyle(isSelected ? iconColor : Color.primary)
-                                .frame(width: 50, height: 50)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .fill(isSelected ? iconColor.opacity(0.2) : Color.clear)
-                                )
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .stroke(isSelected ? iconColor : Color.clear, lineWidth: 2)
-                                )
-                                .onTapGesture { selectedIcon = icon }
-                                .accessibilityLabel(icon.replacingOccurrences(of: ".fill", with: "").replacingOccurrences(of: ".", with: " "))
-                                .accessibilityAddTraits(selectedIcon == icon ? .isSelected : [])
-                        }
-                    }
-                    .padding(.vertical, 8)
-                }
+                HabitStylePicker(colorHex: $selectedColor, iconName: $selectedIcon)
             }
             .navigationTitle("New Habit")
             .navigationBarTitleDisplayMode(.inline)

--- a/ResistorTests/HabitsViewModelTests.swift
+++ b/ResistorTests/HabitsViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SwiftData
+import UIKit
 @testable import Resistor
 
 @MainActor
@@ -392,5 +393,76 @@ final class HabitsViewModelTests: XCTestCase {
         for icon in HabitsViewModel.availableIcons {
             XCTAssertFalse(icon.isEmpty)
         }
+    }
+
+    /// Swatches are identified by hex in `ForEach`, and a duplicate name would
+    /// give VoiceOver two "Teal"s.
+    func testColorsAreDistinct() {
+        let hexes = HabitsViewModel.availableColors.map(\.hex)
+        let names = HabitsViewModel.availableColors.map(\.name)
+        XCTAssertEqual(Set(hexes).count, hexes.count, "duplicate hex in the palette")
+        XCTAssertEqual(Set(names).count, names.count, "duplicate name in the palette")
+    }
+
+    /// A habit colour is drawn as ink on both a white card and a black one, so
+    /// nothing may sit near either end. Doesn't police "muted" — saturation is a
+    /// design judgement — only the lightness that would actually stop rendering.
+    func testColorsAreMidTone() {
+        for color in HabitsViewModel.availableColors {
+            let hex = color.hex.dropFirst()
+            let value = Int(hex, radix: 16) ?? 0
+            let channels = [(value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF]
+            let lightness = Double(channels.max()! + channels.min()!) / 2 / 255
+            XCTAssertGreaterThan(lightness, 0.40, "\(color.name) (\(color.hex)) is too dark")
+            XCTAssertLessThan(lightness, 0.80, "\(color.name) (\(color.hex)) is too light")
+        }
+    }
+
+    /// `allIcons` silently drops a symbol this OS can't draw, which is right for
+    /// an SDK-newer symbol and wrong for a typo — the typo would just never
+    /// appear in the grid. This is the only thing that tells them apart.
+    func testEveryCatalogIconIsARealSymbol() {
+        let missing = (HabitsViewModel.availableIcons + HabitsViewModel.iconCatalog)
+            .filter { UIImage(systemName: $0) == nil }
+        XCTAssertEqual(missing, [], "not SF Symbols on this OS")
+    }
+
+    /// A keyword whose key isn't in the catalogue can never match anything.
+    func testEveryKeywordedIconIsInTheCatalog() {
+        let known = Set(HabitsViewModel.availableIcons + HabitsViewModel.iconCatalog)
+        let orphans = HabitsViewModel.iconKeywords.keys.filter { !known.contains($0) }.sorted()
+        XCTAssertEqual(orphans, [], "keywords for symbols not in the catalog")
+    }
+
+    func testEmptyIconQueryReturnsTheSuggestedSet() {
+        XCTAssertEqual(HabitsViewModel.icons(matching: ""), HabitsViewModel.availableIcons)
+        XCTAssertEqual(HabitsViewModel.icons(matching: "   "), HabitsViewModel.availableIcons)
+    }
+
+    func testIconSearchMatchesNamesAndKeywords() {
+        // By name, with the dot reading as a space.
+        XCTAssertTrue(HabitsViewModel.icons(matching: "run").contains("figure.run"))
+        XCTAssertTrue(HabitsViewModel.icons(matching: "saucer").contains("cup.and.saucer.fill"))
+
+        // By keyword — nothing in the name says "coffee".
+        XCTAssertTrue(HabitsViewModel.icons(matching: "coffee").contains("cup.and.saucer.fill"))
+        XCTAssertTrue(HabitsViewModel.icons(matching: "gambling").contains("dice.fill"))
+
+        // Apple ships no cigarette symbol, so the word has to reach a stand-in
+        // or the app's most likely habit has nothing to search for.
+        XCTAssertTrue(HabitsViewModel.icons(matching: "cigarette").contains("smoke.fill"))
+
+        // Every word has to match, so a second one narrows.
+        XCTAssertTrue(HabitsViewModel.icons(matching: "figure swim").contains("figure.pool.swim"))
+        XCTAssertFalse(HabitsViewModel.icons(matching: "figure swim").contains("figure.run"))
+
+        XCTAssertEqual(HabitsViewModel.icons(matching: "zzzzz"), [])
+    }
+
+    func testIconSearchIsCaseInsensitive() {
+        XCTAssertEqual(
+            HabitsViewModel.icons(matching: "Coffee"),
+            HabitsViewModel.icons(matching: "coffee")
+        )
     }
 }

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,40 +1,32 @@
-Naming a place no longer has to be typing.
+The habit editor's icon and colour choices were too narrow to name what you're
+actually tracking. Both are wider now.
 
-Open the Name This Place sheet and it now offers names as one-tap fills, under
-"Nearby": the businesses at that coordinate, and — if you turn on contact
-matching — anyone in your address book who lives there. There is also a "From
-Contacts" button that opens the system contact picker, for the places that are a
-person's rather than a business.
+Icons have a search box. Leave it empty and you get the same twenty as before —
+the common case is unchanged. Type into it and you reach a much larger set:
+"coffee", "gambling", "sleep", "run", "shopping", "phone". It matches the symbol
+name and a list of synonyms, so words Apple's own naming doesn't use still find
+something.
 
-There is a third way into the sheet now, alongside tapping a pin on the Event Map
-and the Location row in an event's detail: swipe a History row from the left. It
-appears only on rows still showing a neighbourhood or a raw coordinate, which is
-the moment naming is worth offering.
+Colours went from 10 to 20, ordered warm through cool to neutral. Still mid-tone
+only — a habit colour is also chart ink on Insights, a glyph on the Log card, and
+the widget's tint, so nothing goes near white or black.
 
-Nothing is applied for you. A hundred-metre fix in a strip mall has a dozen
-plausible answers, and a confidently wrong one is worse than none, because a
-place name feeds Insights and the Patterns card. The suggestions fill the text
-field; you still confirm with Save, and you can still type anything.
+Both pickers are now one piece of code, shared by the Habits editor and the Add
+Habit sheet on the Log screen. They were separate copies and only one of them
+would otherwise have got the search.
 
-Contact matching is off until you press Habits › Contacts › "Match My Contacts".
-That one asks for address-book access and takes about a second per contact, so
-give it a moment on a large address book. The addresses are stored on the phone
-only — unlike everything else in the app they are never synced to iCloud, so
-you would run it once per device. "Remove Contact Matches" deletes them.
+One real bug fell out of building this. The "cigarette" icon has never existed —
+there is no cigarette symbol in SF Symbols under any name — so that tile has been
+blank since the first build, and so was the glyph on any habit that picked it. It
+now offers a smoke symbol instead, and searching "cigarette" finds it. If you
+have a habit showing no icon at all, that is why; open it and pick again.
 
-The "From Contacts" button needs none of that: the picker runs outside the app,
-asks for no permission, and hands back only the name of the contact you tap.
-Neither path stores an address on the event — the place still saves at the
-coordinate you logged at.
+Worth checking: search a few words for something you actually track and see
+whether anything sensible comes back; confirm an empty search still shows the
+original twenty; open a habit you created earlier and confirm its icon is still
+selected in the grid; confirm the new colours look right on both a Log card and
+an Insights chart, in dark mode as well as light.
 
-Worth checking: open the sheet somewhere with businesses around and confirm the
-Nearby list is plausible; confirm "From Contacts" opens the picker without a
-permission prompt; run contact matching and confirm a friend's name shows up when
-you log at their place; confirm the History swipe offers "Name" on an unnamed row
-and not on one already named; confirm an event logged in transit still offers no
-naming at all.
-
-The useful thing to report: how long contact matching takes and how many of your
-contacts it found, a Nearby list that is empty or obviously wrong where you would
-expect a business, and whether the contact picker ever prompts for address-book
-access.
+The useful thing to report: a word you searched that found nothing when it should
+have — that is a missing synonym and it's a one-line fix. Also any colour that
+looks wrong as a chart bar or disappears against the background in either mode.

--- a/scripts/add_habit_style_picker.rb
+++ b/scripts/add_habit_style_picker.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+# Adds Views/HabitStylePicker.swift to the Resistor target. Idempotent.
+#
+#   gem install xcodeproj && ruby scripts/add_habit_style_picker.rb
+
+require 'xcodeproj'
+
+project_path = File.expand_path('../Resistor.xcodeproj', __dir__)
+project = Xcodeproj::Project.open(project_path)
+
+target = project.targets.find { |t| t.name == 'Resistor' } or abort 'No Resistor target'
+views = project.main_group.find_subpath('Resistor/Views', true)
+
+path = 'HabitStylePicker.swift'
+ref = views.files.find { |f| f.path == path } || views.new_file(path)
+
+if target.source_build_phase.files_references.include?(ref)
+  puts "HabitStylePicker.swift already in Resistor"
+else
+  target.add_file_references([ref])
+  puts "Added HabitStylePicker.swift to Resistor"
+end
+
+project.save


### PR DESCRIPTION
Closes #63. Closes #82.

The editor offered 20 SF Symbols and 10 colours, so anyone tracking something the list didn't anticipate had no glyph for it.

## Icons

A search box over a hand-curated catalogue. **Empty query still returns the same suggested twenty**, so the common case doesn't change; typing reaches the rest.

There is no public API to enumerate SF Symbols, so the catalogue is written out — curated rather than exhaustive, because a flat grid of several thousand symbols is unusable. Three parts in `HabitsViewModel`: `availableIcons` (the suggested set), `iconCatalog` (everything else, grouped by what someone might be tracking), and `iconKeywords` (words a symbol's own name doesn't contain — matching already reads dots as spaces so "run" finds `figure.run`, but nothing in `cup.and.saucer.fill` says coffee).

## Colours

10 → 20, ordered warm through cool to neutral rather than by when a hue was added, so the grid reads as a sweep. Mid-tone only, as the issue requires: a habit colour is chart ink on Insights, a filled glyph on both a white card and a black one, and the widget's tint. Sand stays at index 0 because that's what a new habit takes.

## One picker, not two

The Habits editor and the Log screen's Add Habit sheet carried byte-identical copies of both grids. They're now one `HabitStylePicker`, so the search only had to be built once and the two can't drift. It also prepends the selected icon to the default grid when that icon isn't one of the suggested twenty — otherwise editing a habit whose icon came from a search opens on a grid with nothing selected in it.

Onboarding keeps its own horizontal strips and gets no search: it's a first-run scroll strip rather than a form, and the icon is changeable a tap later. It picks up the wider palette for free.

## The bug this found

`"cigarette.fill"` has been in the shipped palette since v1. **There is no cigarette symbol in SF Symbols under any name**, so `UIImage(systemName:)` returns nil and that tile — plus the glyph on the Log card, History row, widget and watch for any habit that picked it — has always drawn a blank. Nothing crashes, which is why it survived a year; smoking being near the app's central use case, it was close to the worst entry to have broken.

`smoke.fill` replaces it, with `"cigarette"` as a keyword on `smoke.fill` and `lungs.fill` so the word still reaches a glyph.

The two defences look redundant and aren't: `allIcons` filters through `UIImage(systemName:)` at runtime so a symbol from a *later* SDK degrades to absent on an older OS, while `testEveryCatalogIconIsARealSymbol` fails the build on a typo. Without the test, a typo is indistinguishable from the first case — which is exactly how this shipped.

**Not fixed:** an existing habit whose stored `iconName` is the dead string keeps rendering blank. It renders blank today too, so nothing regresses, and re-picking is now easy. Given the tile was blank at pick time, it's unlikely anyone chose it. Called out in the TestFlight notes.

## Verified

- `** BUILD SUCCEEDED **` (iOS), `** BUILD SUCCEEDED **` (ResistorWatch)
- `Executed 332 tests, with 0 failures` + 2 UI tests
- Screenshot harness: 20-swatch grid and the search field render correctly; filtered grid, clear button and selection ring checked by temporarily seeding a query

New tests: every catalogue symbol resolves; every keyword names a real catalogue entry; empty query returns the suggested set; search matches names, keywords, and narrows on a second word; case-insensitive; palette hexes are distinct and mid-tone.

Not verified: nothing on hardware — this is all static data and standard SwiftUI, with no permission or schema surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sdMoCETcfDumJBdarLpba